### PR TITLE
fix(parser): align export default async linebreak to estree

### DIFF
--- a/src/parser/syntax/modules.zig
+++ b/src/parser/syntax/modules.zig
@@ -518,9 +518,10 @@ fn parseExportDefaultPart(parser: *Parser) Error!?DefaultExportPart {
     }
 
     if (tag == .async and !parser.current_token.hasLineTerminatorBefore()) {
-        const async_start = parser.current_token.span.start;
-        try parser.advance() orelse return null;
-        if (parser.current_token.tag == .function) {
+        const next = parser.peekAhead() orelse return null;
+        if (next.tag == .function and !next.hasLineTerminatorBefore()) {
+            const async_start = parser.current_token.span.start;
+            try parser.advance() orelse return null;
             const decl = try functions.parseFunction(
                 parser,
                 .{ .is_default_export = true, .is_async = true },
@@ -528,15 +529,6 @@ fn parseExportDefaultPart(parser: *Parser) Error!?DefaultExportPart {
             ) orelse return null;
             return .{ .declaration = decl, .needs_semi = false };
         }
-        // export default async as identifier value
-        const async_end = async_start + 5;
-        const id = try parser.tree.addNode(
-            .{ .identifier_reference = .{
-                .name = parser.tree.sourceSlice(async_start, async_end),
-            } },
-            .{ .start = async_start, .end = async_end },
-        );
-        return .{ .declaration = id, .needs_semi = true };
     }
 
     if (tag == .class) {

--- a/test/parser/misc/js/export-default-async-linebreak.module.js
+++ b/test/parser/misc/js/export-default-async-linebreak.module.js
@@ -1,0 +1,2 @@
+export default async
+function f() {}

--- a/test/parser/misc/js/snapshots/export-default-async-linebreak.snapshot.json
+++ b/test/parser/misc/js/snapshots/export-default-async-linebreak.snapshot.json
@@ -1,0 +1,45 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 37,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "ExportDefaultDeclaration",
+        "start": 0,
+        "end": 20,
+        "declaration": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 20,
+          "name": "async"
+        }
+      },
+      {
+        "type": "FunctionDeclaration",
+        "start": 21,
+        "end": 36,
+        "id": {
+          "type": "Identifier",
+          "start": 30,
+          "end": 31,
+          "name": "f"
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 34,
+          "end": 36,
+          "body": []
+        },
+        "expression": false
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/results/test_parser_misc_js.txt
+++ b/test/parser/results/test_parser_misc_js.txt
@@ -1,8 +1,8 @@
 test/parser/misc/js
 ===================
-Passed:       42/42 (100.00%)
+Passed:       43/43 (100.00%)
 Failed:       0
-AST mismatch: 0/42
+AST mismatch: 0/43
 
 ✓ test/parser/misc/js/accessor-line-terminator.js
 ✓ test/parser/misc/js/async-arrow-function-line-terminator-1.js
@@ -77,6 +77,7 @@ error: 'await' is reserved in an async/module context and cannot be used as an i
 ✓ test/parser/misc/js/class-static-block-await-context.js
 ✓ test/parser/misc/js/dynamic-import-in-script.js
 ✓ test/parser/misc/js/dynamic-import.module.js
+✓ test/parser/misc/js/export-default-async-linebreak.module.js
 ✓ test/parser/misc/js/export-default-using.module.js
 error: Expected a semicolon or an implicit semicolon after a statement, but found 'resource'
    |


### PR DESCRIPTION
Another one difference.

[oxc](https://playground.oxc.rs/?t=ast&options=%7B%22run%22%3A%7B%22lint%22%3Atrue%2C%22formatter%22%3Afalse%2C%22transform%22%3Afalse%2C%22isolatedDeclarations%22%3Afalse%2C%22whitespace%22%3Afalse%2C%22mangle%22%3Afalse%2C%22compress%22%3Afalse%2C%22scope%22%3Atrue%2C%22symbol%22%3Atrue%2C%22cfg%22%3Afalse%7D%2C%22parser%22%3A%7B%22extension%22%3A%22ts%22%2C%22allowReturnOutsideFunction%22%3Atrue%2C%22preserveParens%22%3Atrue%2C%22allowV8Intrinsics%22%3Atrue%2C%22semanticErrors%22%3Atrue%7D%2C%22linter%22%3A%7B%7D%2C%22formatter%22%3A%7B%22useTabs%22%3Afalse%2C%22tabWidth%22%3A2%2C%22endOfLine%22%3A%22lf%22%2C%22printWidth%22%3A80%2C%22singleQuote%22%3Afalse%2C%22jsxSingleQuote%22%3Afalse%2C%22quoteProps%22%3A%22as-needed%22%2C%22trailingComma%22%3A%22all%22%2C%22semi%22%3Atrue%2C%22arrowParens%22%3A%22always%22%2C%22bracketSpacing%22%3Atrue%2C%22bracketSameLine%22%3Afalse%2C%22objectWrap%22%3A%22preserve%22%2C%22singleAttributePerLine%22%3Afalse%7D%2C%22transformer%22%3A%7B%22target%22%3A%22es2015%22%2C%22useDefineForClassFields%22%3Atrue%2C%22experimentalDecorators%22%3Atrue%2C%22emitDecoratorMetadata%22%3Atrue%2C%22optimizeEnums%22%3Atrue%2C%22optimizeConstEnums%22%3Atrue%7D%2C%22isolatedDeclarations%22%3A%7B%22stripInternal%22%3Afalse%7D%2C%22codegen%22%3A%7B%22normal%22%3Atrue%2C%22jsdoc%22%3Atrue%2C%22annotation%22%3Atrue%2C%22legal%22%3Atrue%7D%2C%22compress%22%3A%7B%7D%2C%22mangle%22%3A%7B%22topLevel%22%3Atrue%2C%22keepNames%22%3Afalse%7D%2C%22controlFlow%22%3A%7B%22verbose%22%3Afalse%7D%2C%22inject%22%3A%7B%22inject%22%3A%7B%7D%7D%2C%22define%22%3A%7B%22define%22%3A%7B%7D%7D%7D&code=export+default+async%0Afunction+f%28%29+%7B%7D%0A)

[estree](https://typescript-eslint.io/play/#ts=6.0.2&showAST=es&fileType=.tsx&code=FBA&eslintrc=N4KABGBEBOCuA2BTAzpAXGYBfEWg&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)