### PR TITLE
Add TSRX parser support

### DIFF
--- a/docs/content/parser/ast.smd
+++ b/docs/content/parser/ast.smd
@@ -46,7 +46,7 @@ All memory is owned by a single `ArenaAllocator`. `tree.deinit()` frees the enti
 | `diagnostics` | `ArrayList(Diagnostic)` | Parse errors, warnings, hints                              |
 | `source`      | `[]const u8`            | Original source text                                       |
 | `source_type` | `SourceType`            | `.script` or `.module`                                     |
-| `lang`        | `Lang`                  | `.js`, `.ts`, `.jsx`, `.tsx`, or `.dts`                    |
+| `lang`        | `Lang`                  | `.js`, `.ts`, `.jsx`, `.tsx`, `.dts`, or `.tsrx`           |
 
 Everything else is reached through methods:
 
@@ -57,8 +57,8 @@ tree.extra(range)        // []const NodeIndex for an IndexRange
 tree.string(handle)      // []const u8 for a String handle
 tree.commentsOf(idx)     // []const AttachedComment attached to the node at idx
 
-tree.isTs()              // language is .ts, .tsx, or .dts
-tree.isJsx()             // language is .jsx or .tsx
+tree.isTs()              // language is .ts, .tsx, .dts, or .tsrx
+tree.isJsx()             // language is .jsx, .tsx, or .tsrx
 tree.isModule()          // source_type is .module
 tree.hasErrors()         // any diagnostic with severity .error
 ```
@@ -364,6 +364,9 @@ const foo = bar.baz;
 | `formal_parameters`    | `(a, b = 1, ...rest)`           | The parameter list of a function.                                                  |
 | `formal_parameter`     | a single parameter slot         | A single parameter slot wrapping a binding pattern.                                |
 
+In `.tsrx` trees, `&{...}` and `&[...]` set `lazy = true` on the object or array
+pattern node.
+
 ### [Functions]($section.id('functions'))
 
 ```zig
@@ -374,7 +377,7 @@ pub const Function = struct {
     async: bool,           // true for async function
     declare: bool,         // true for declare function
     params: NodeIndex,     // formal_parameters
-    body: NodeIndex,       // function_body (.null for TS overloads / abstract)
+    body: NodeIndex,       // function_body, jsx_code_block, or .null
     type_parameters: NodeIndex,  // ts_type_parameter_declaration or .null
     return_type: NodeIndex,      // ts_type_annotation or .null
 };
@@ -383,7 +386,7 @@ pub const Function = struct {
 | Tag                         | Description                                                                    |
 | --------------------------- | ------------------------------------------------------------------------------ |
 | `function`                  | Every named and anonymous function form, including ambient and body-less ones. |
-| `function_body`             | The braced body of a function.                                                 |
+| `function_body`             | The braced body of a function. `.tsrx` functions may use `jsx_code_block`.     |
 | `arrow_function_expression` | An arrow function, with either an expression or a block body.                  |
 
 ### [Classes]($section.id('classes'))
@@ -429,7 +432,7 @@ pub const Class = struct {
 
 ### [JSX]($section.id('jsx'))
 
-JSX nodes are only present in `.jsx` and `.tsx` trees.
+JSX nodes are only present in `.jsx`, `.tsx`, and `.tsrx` trees.
 
 | Tag                        | Syntax                      | Description                                              |
 | -------------------------- | --------------------------- | -------------------------------------------------------- |
@@ -448,14 +451,19 @@ JSX nodes are only present in `.jsx` and `.tsx` trees.
 | `jsx_empty_expression`     | `{}`                        | The empty `{}` placeholder inside a JSX expression slot. |
 | `jsx_text`                 | text content between tags   | A span of raw text inside a JSX element or fragment.     |
 | `jsx_spread_child`         | `{...children}`             | A spread child inside a JSX element.                     |
+| `jsx_code_block`           | `@{ statements }`           | A TSRX statement block inside JSX children.              |
 
-A JSX tag name (the `name` field on `jsx_opening_element`, `jsx_closing_element`, and one form of `jsx_attribute`) is one of `jsx_identifier`, `jsx_namespaced_name`, or `jsx_member_expression`.
+A JSX tag name is one of `jsx_identifier`, `jsx_namespaced_name`,
+`jsx_member_expression`, or a `jsx_expression_container` dynamic tag in `.tsrx`.
 
-A JSX child (entries in the `children` list on `jsx_element` and `jsx_fragment`) is one of `jsx_text`, `jsx_expression_container`, `jsx_spread_child`, `jsx_element`, or `jsx_fragment`.
+A JSX child, which is an entry in the `children` list on `jsx_element` and
+`jsx_fragment`, is one of `jsx_text`, `jsx_expression_container`,
+`jsx_spread_child`, `jsx_element`, `jsx_fragment`, or a `.tsrx`
+`jsx_code_block`.
 
 ## [TypeScript]($section.id('typescript'))
 
-TypeScript nodes are present in `.ts`, `.tsx`, and `.dts` trees.
+TypeScript nodes are present in `.ts`, `.tsx`, `.dts`, and `.tsrx` trees.
 
 ### [Type wrapper]($section.id('type-wrapper'))
 
@@ -604,7 +612,7 @@ These appear inside `ts_type_literal.members` and `ts_interface_body.body`.
 | ----------------------------- | ------------------ | --------------------------------------------------------- |
 | `ts_as_expression`            | `expr as T`        | A postfix `as` type assertion.                            |
 | `ts_satisfies_expression`     | `expr satisfies T` | A postfix `satisfies` constraint check.                   |
-| `ts_type_assertion`           | `<T>expr`          | A prefix `<T>` type assertion. Forbidden in `.tsx`.       |
+| `ts_type_assertion`           | `<T>expr`          | A prefix `<T>` type assertion. Forbidden in `.tsx` and `.tsrx`. |
 | `ts_non_null_expression`      | `expr!`            | A postfix non-null assertion.                             |
 | `ts_instantiation_expression` | `expr<T>`          | A type instantiation expression without call parentheses. |
 

--- a/docs/content/parser/index.smd
+++ b/docs/content/parser/index.smd
@@ -71,7 +71,7 @@ const tree = try parser.parse(allocator, source, .{
 | Field                           | Values                               | Default   | Description                                                                       |
 | ------------------------------- | ------------------------------------ | --------- | --------------------------------------------------------------------------------- |
 | `source_type`                   | `.script`, `.module`                 | `.module` | Script mode or ES module mode (strict mode)                                       |
-| `lang`                          | `.js`, `.ts`, `.jsx`, `.tsx`, `.dts` | `.js`     | Language variant and syntax features to enable                                    |
+| `lang`                          | `.js`, `.ts`, `.jsx`, `.tsx`, `.dts`, `.tsrx` | `.js`     | Language variant and syntax features to enable                          |
 | `preserve_parens`               | `true`, `false`                      | `true`    | Keep `ParenthesizedExpression` nodes in the AST                                   |
 | `allow_return_outside_function` | `true`, `false`                      | `false`   | Allow `return` statements at the top level                                        |
 | `comments`                      | `.none`, `.flat`, `.attached`, `.both` | `.flat` | Collect comments: as a flat list (`tree.comments`), attached to host nodes (`tree.commentsOf`), or both. See [Comments](/parser/ast/#comments) |
@@ -81,7 +81,7 @@ Both fields can be inferred from a file path:
 ```zig
 const tree = try parser.parse(allocator, source, .{
     .source_type = .fromPath("app.cjs"), // .script
-    .lang = .fromPath("app.tsx"),               // .tsx
+    .lang = .fromPath("app.tsrx"),              // .tsrx
 });
 ```
 

--- a/npm/yuku-analyzer/analyzer.js
+++ b/npm/yuku-analyzer/analyzer.js
@@ -1,6 +1,16 @@
 import { Module, SymbolFlags } from "./module.js";
 
-const RESOLVE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mts", ".mjs", ".cts", ".cjs"];
+const RESOLVE_EXTENSIONS = [
+    ".tsrx",
+    ".tsx",
+    ".ts",
+    ".jsx",
+    ".js",
+    ".mts",
+    ".mjs",
+    ".cts",
+    ".cjs",
+];
 
 // name supplied ambiguously by multiple export * (ResolveExport, 16.2.1.7.2.2)
 const AMBIGUOUS = Symbol("ambiguous");

--- a/npm/yuku-analyzer/decode.js
+++ b/npm/yuku-analyzer/decode.js
@@ -84,7 +84,7 @@ _ck("SwitchStatement", ["discriminant", "cases"]);
 _ck("SwitchCase", ["test", "consequent"]);
 _ck("ForStatement", ["init", "test", "update", "body"]);
 _ck("ForInStatement", ["left", "right", "body"]);
-_ck("ForOfStatement", ["left", "right", "body"]);
+_ck("ForOfStatement", ["left", "right", "body", "index", "key"]);
 _ck("WhileStatement", ["test", "body"]);
 _ck("DoWhileStatement", ["body", "test"]);
 _ck("BreakStatement", ["label"]);
@@ -94,7 +94,7 @@ _ck("WithStatement", ["object", "body"]);
 _ck("ReturnStatement", ["argument"]);
 _ck("ThrowStatement", ["argument"]);
 _ck("TryStatement", ["block", "handler", "finalizer"]);
-_ck("CatchClause", ["param", "body"]);
+_ck("CatchClause", ["param", "resetParam", "body"]);
 _ck("DebuggerStatement", []);
 _ck("EmptyStatement", []);
 _ck("VariableDeclaration", ["declarations"]);
@@ -202,6 +202,13 @@ _ck("JSXExpressionContainer", ["expression"]);
 _ck("JSXEmptyExpression", []);
 _ck("JSXText", []);
 _ck("JSXSpreadChild", ["expression"]);
+_ck("JSXCodeBlock", ["body", "render"]);
+_ck("StyleSheet", []);
+_ck("JSXStyleElement", ["openingElement", "children", "closingElement"]);
+_ck("JSXIfExpression", ["test", "consequent", "alternate"]);
+_ck("JSXForExpression", ["statement", "empty"]);
+_ck("JSXSwitchExpression", ["statement"]);
+_ck("JSXTryExpression", ["statement", "pending"]);
 _ck("Hashbang", []);
 const SCOPE_KINDS = ["global", "module", "function", "block", "class", "staticBlock", "expressionName", "tsModule"];
 const NAME_KINDS = ["named", "star", "none", "equals", "global"];
@@ -285,7 +292,7 @@ const CHILD_SLOTS = [
   [0, 2, 2, 3],
   [0, 2, 0, 3, 0, 4, 0, 5],
   [0, 2, 0, 3, 0, 4],
-  [0, 2, 0, 3, 0, 4],
+  [0, 2, 0, 3, 0, 4, 0, 5, 0, 6],
   [0, 2, 0, 3],
   [0, 2, 0, 3],
   [0, 2],
@@ -295,7 +302,7 @@ const CHILD_SLOTS = [
   [0, 2],
   [0, 2],
   [0, 2, 0, 3, 0, 4],
-  [0, 2, 0, 3],
+  [0, 2, 0, 3, 0, 4],
   [],
   [],
   [2, 2],
@@ -403,6 +410,13 @@ const CHILD_SLOTS = [
   [],
   [],
   [0, 2],
+  [2, 2, 0, 3],
+  [],
+  [0, 2, 2, 3, 0, 4],
+  [0, 2, 0, 3, 0, 4],
+  [0, 2, 0, 3],
+  [0, 2],
+  [0, 2, 0, 3],
 ];
 const IS_NODE = [
   true,
@@ -413,6 +427,13 @@ const IS_NODE = [
   true,
   false,
   false,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
   true,
   true,
   true,
@@ -927,7 +948,7 @@ function decode(buffer, source) {
     case 50: return { type: "SwitchCase", start, end, test: f1 !== NULL ? node(f1) : null, consequent: nodeArr(f2, f0) };
     case 51: return { type: "ForStatement", start, end, init: f1 !== NULL ? node(f1) : null, test: f2 !== NULL ? node(f2) : null, update: f3 !== NULL ? node(f3) : null, body: f4 !== NULL ? node(f4) : null };
     case 52: return { type: "ForInStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null };
-    case 53: return { type: "ForOfStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null, await: !!(flags & 1) };
+    case 53: return { type: "ForOfStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null, await: !!(flags & 1), index: f4 !== NULL ? node(f4) : null, key: f5 !== NULL ? node(f5) : null };
     case 54: return { type: "WhileStatement", start, end, test: f1 !== NULL ? node(f1) : null, body: f2 !== NULL ? node(f2) : null };
     case 55: return { type: "DoWhileStatement", start, end, body: f1 !== NULL ? node(f1) : null, test: f2 !== NULL ? node(f2) : null };
     case 56: return { type: "BreakStatement", start, end, label: f1 !== NULL ? node(f1) : null };
@@ -937,7 +958,7 @@ function decode(buffer, source) {
     case 60: return { type: "ReturnStatement", start, end, argument: f1 !== NULL ? node(f1) : null };
     case 61: return { type: "ThrowStatement", start, end, argument: f1 !== NULL ? node(f1) : null };
     case 62: return { type: "TryStatement", start, end, block: f1 !== NULL ? node(f1) : null, handler: f2 !== NULL ? node(f2) : null, finalizer: f3 !== NULL ? node(f3) : null };
-    case 63: return { type: "CatchClause", start, end, param: f1 !== NULL ? node(f1) : null, body: f2 !== NULL ? node(f2) : null };
+    case 63: return { type: "CatchClause", start, end, param: f1 !== NULL ? node(f1) : null, resetParam: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null };
     case 64: return { type: "DebuggerStatement", start, end };
     case 65: return { type: "EmptyStatement", start, end };
     case 66: { const r = { type: "VariableDeclaration", start, end, kind: VAR_KINDS[flags & 7], declarations: nodeArr(f1, f0) }; if (_isTs) { r.declare = !!(flags & 8); } return r; }
@@ -952,9 +973,10 @@ function decode(buffer, source) {
       const el = nodeArrHoles(f1, f0);
       if (f2 !== NULL) el.push(node(f2));
       const r = { type: "ArrayPattern", start, end, elements: el };
+      if (flags & 1) r.lazy = true;
       if (_isTs) {
         r.decorators = nodeArr(f3, f4);
-        r.optional = !!(flags & 1);
+        r.optional = !!(flags & 2);
         r.typeAnnotation = f5 !== NULL ? node(f5) : null;
       }
       return r;
@@ -963,9 +985,10 @@ function decode(buffer, source) {
       const pr = nodeArr(f1, f0);
       if (f2 !== NULL) pr.push(node(f2));
       const r = { type: "ObjectPattern", start, end, properties: pr };
+      if (flags & 1) r.lazy = true;
       if (_isTs) {
         r.decorators = nodeArr(f3, f4);
-        r.optional = !!(flags & 1);
+        r.optional = !!(flags & 2);
         r.typeAnnotation = f5 !== NULL ? node(f5) : null;
       }
       return r;
@@ -1148,6 +1171,13 @@ function decode(buffer, source) {
       return { type: "JSXText", start, end, value: t, raw: t };
     }
     case 170: return { type: "JSXSpreadChild", start, end, expression: f1 !== NULL ? node(f1) : null };
+    case 171: return { type: "JSXCodeBlock", start, end, body: nodeArr(f1, f0), render: f2 !== NULL ? node(f2) : null };
+    case 172: return { type: "StyleSheet", start, end, source: str(f1, f2) };
+    case 173: return { type: "JSXStyleElement", start, end, openingElement: f1 !== NULL ? node(f1) : null, children: nodeArr(f2, f0), closingElement: f3 !== NULL ? node(f3) : null, css: str(f4, f5) };
+    case 174: return { type: "JSXIfExpression", start, end, test: f1 !== NULL ? node(f1) : null, consequent: f2 !== NULL ? node(f2) : null, alternate: f3 !== NULL ? node(f3) : null };
+    case 175: return { type: "JSXForExpression", start, end, statement: f1 !== NULL ? node(f1) : null, empty: f2 !== NULL ? node(f2) : null };
+    case 176: return { type: "JSXSwitchExpression", start, end, statement: f1 !== NULL ? node(f1) : null };
+    case 177: return { type: "JSXTryExpression", start, end, statement: f1 !== NULL ? node(f1) : null, pending: f2 !== NULL ? node(f2) : null };
     }
   }
   const _inner = _attached ? nodeWithComments : _decode;

--- a/npm/yuku-analyzer/module.js
+++ b/npm/yuku-analyzer/module.js
@@ -5,6 +5,7 @@ import { walkModule } from "./walk.js";
 
 export function langFromPath(path) {
   if (path.endsWith(".d.ts") || path.endsWith(".d.mts") || path.endsWith(".d.cts")) return "dts";
+  if (path.endsWith(".tsrx")) return "tsrx";
   if (path.endsWith(".tsx")) return "tsx";
   if (path.endsWith(".ts") || path.endsWith(".mts") || path.endsWith(".cts")) return "ts";
   if (path.endsWith(".jsx")) return "jsx";

--- a/npm/yuku-codegen-wasm/encode.js
+++ b/npm/yuku-codegen-wasm/encode.js
@@ -831,11 +831,15 @@ function encode(program) {
     const c_left = n.left == null ? NULL : encNode(n.left);
     const c_right = n.right == null ? NULL : encNode(n.right);
     const c_body = n.body == null ? NULL : encNode(n.body);
+    const c_index = n.index == null ? NULL : encNode(n.index);
+    const c_key = n.key == null ? NULL : encNode(n.key);
     const idx = alloc();
     tagAt(idx, 53);
     slotAt(idx, 0, c_left);
     slotAt(idx, 1, c_right);
     slotAt(idx, 2, c_body);
+    slotAt(idx, 3, c_index);
+    slotAt(idx, 4, c_key);
     flagsAt(idx, 0 | (n.await ? 1 : 0));
     spanAt(idx, asStart(n), asEnd(n));
     recordComments(n, idx);
@@ -936,11 +940,13 @@ function encode(program) {
   }
   function enc_catch_clause(n) {
     const c_param = n.param == null ? NULL : encBindingTarget(n.param);
+    const c_reset_param = n.resetParam == null ? NULL : encNode(n.resetParam);
     const c_body = n.body == null ? NULL : encNode(n.body);
     const idx = alloc();
     tagAt(idx, 63);
     slotAt(idx, 0, c_param);
-    slotAt(idx, 1, c_body);
+    slotAt(idx, 1, c_reset_param);
+    slotAt(idx, 2, c_body);
     spanAt(idx, asStart(n), asEnd(n));
     recordComments(n, idx);
     return idx;
@@ -1045,7 +1051,7 @@ function encode(program) {
     slotAt(idx, 1, rest);
     slotAt(idx, 2, decs.start); slotAt(idx, 3, decs.len);
     slotAt(idx, 4, ta);
-    flagsAt(idx, n.optional ? 1 : 0);
+    flagsAt(idx, (n.lazy ? 1 : 0) | (n.optional ? 2 : 0));
     spanAt(idx, asStart(n), asEnd(n));
     recordComments(n, idx);
     return idx;
@@ -1069,7 +1075,7 @@ function encode(program) {
     slotAt(idx, 1, rest);
     slotAt(idx, 2, decs.start); slotAt(idx, 3, decs.len);
     slotAt(idx, 4, ta);
-    flagsAt(idx, n.optional ? 1 : 0);
+    flagsAt(idx, (n.lazy ? 1 : 0) | (n.optional ? 2 : 0));
     spanAt(idx, asStart(n), asEnd(n));
     recordComments(n, idx);
     return idx;
@@ -2109,6 +2115,89 @@ function encode(program) {
     recordComments(n, idx);
     return idx;
   }
+  function enc_jsx_code_block(n) {
+    const c_body = encArr(n.body, encNode);
+    const c_render = n.render == null ? NULL : encNode(n.render);
+    const idx = alloc();
+    tagAt(idx, 171);
+    f0At(idx, c_body.len);
+    slotAt(idx, 0, c_body.start);
+    slotAt(idx, 1, c_render);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_style_sheet(n) {
+    const c_source = encStr(n.source);
+    const idx = alloc();
+    tagAt(idx, 172);
+    slotAt(idx, 0, c_source.start);
+    slotAt(idx, 1, c_source.end);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_style_element(n) {
+    const c_opening_element = n.openingElement == null ? NULL : encNode(n.openingElement);
+    const c_children = encArr(n.children, encNode);
+    const c_closing_element = n.closingElement == null ? NULL : encNode(n.closingElement);
+    const c_css = encStr(n.css);
+    const idx = alloc();
+    tagAt(idx, 173);
+    slotAt(idx, 0, c_opening_element);
+    f0At(idx, c_children.len);
+    slotAt(idx, 1, c_children.start);
+    slotAt(idx, 2, c_closing_element);
+    slotAt(idx, 3, c_css.start);
+    slotAt(idx, 4, c_css.end);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_if_expression(n) {
+    const c_test = n.test == null ? NULL : encNode(n.test);
+    const c_consequent = n.consequent == null ? NULL : encNode(n.consequent);
+    const c_alternate = n.alternate == null ? NULL : encNode(n.alternate);
+    const idx = alloc();
+    tagAt(idx, 174);
+    slotAt(idx, 0, c_test);
+    slotAt(idx, 1, c_consequent);
+    slotAt(idx, 2, c_alternate);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_for_expression(n) {
+    const c_statement = n.statement == null ? NULL : encNode(n.statement);
+    const c_empty = n.empty == null ? NULL : encNode(n.empty);
+    const idx = alloc();
+    tagAt(idx, 175);
+    slotAt(idx, 0, c_statement);
+    slotAt(idx, 1, c_empty);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_switch_expression(n) {
+    const c_statement = n.statement == null ? NULL : encNode(n.statement);
+    const idx = alloc();
+    tagAt(idx, 176);
+    slotAt(idx, 0, c_statement);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_try_expression(n) {
+    const c_statement = n.statement == null ? NULL : encNode(n.statement);
+    const c_pending = n.pending == null ? NULL : encNode(n.pending);
+    const idx = alloc();
+    tagAt(idx, 177);
+    slotAt(idx, 0, c_statement);
+    slotAt(idx, 1, c_pending);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
   const commentsByIdx = new Map();
   function encNode(n) {
     if (n == null) return NULL;
@@ -2292,6 +2381,13 @@ function encode(program) {
       case "JSXEmptyExpression": return enc_jsx_empty_expression(n);
       case "JSXText": return enc_jsx_text(n);
       case "JSXSpreadChild": return enc_jsx_spread_child(n);
+      case "JSXCodeBlock": return enc_jsx_code_block(n);
+      case "StyleSheet": return enc_style_sheet(n);
+      case "JSXStyleElement": return enc_jsx_style_element(n);
+      case "JSXIfExpression": return enc_jsx_if_expression(n);
+      case "JSXForExpression": return enc_jsx_for_expression(n);
+      case "JSXSwitchExpression": return enc_jsx_switch_expression(n);
+      case "JSXTryExpression": return enc_jsx_try_expression(n);
       default: throw new Error("yuku-codegen: unsupported ESTree node type: " + n.type);
     }
   }

--- a/npm/yuku-codegen/encode.js
+++ b/npm/yuku-codegen/encode.js
@@ -831,11 +831,15 @@ function encode(program) {
     const c_left = n.left == null ? NULL : encNode(n.left);
     const c_right = n.right == null ? NULL : encNode(n.right);
     const c_body = n.body == null ? NULL : encNode(n.body);
+    const c_index = n.index == null ? NULL : encNode(n.index);
+    const c_key = n.key == null ? NULL : encNode(n.key);
     const idx = alloc();
     tagAt(idx, 53);
     slotAt(idx, 0, c_left);
     slotAt(idx, 1, c_right);
     slotAt(idx, 2, c_body);
+    slotAt(idx, 3, c_index);
+    slotAt(idx, 4, c_key);
     flagsAt(idx, 0 | (n.await ? 1 : 0));
     spanAt(idx, asStart(n), asEnd(n));
     recordComments(n, idx);
@@ -936,11 +940,13 @@ function encode(program) {
   }
   function enc_catch_clause(n) {
     const c_param = n.param == null ? NULL : encBindingTarget(n.param);
+    const c_reset_param = n.resetParam == null ? NULL : encNode(n.resetParam);
     const c_body = n.body == null ? NULL : encNode(n.body);
     const idx = alloc();
     tagAt(idx, 63);
     slotAt(idx, 0, c_param);
-    slotAt(idx, 1, c_body);
+    slotAt(idx, 1, c_reset_param);
+    slotAt(idx, 2, c_body);
     spanAt(idx, asStart(n), asEnd(n));
     recordComments(n, idx);
     return idx;
@@ -1045,7 +1051,7 @@ function encode(program) {
     slotAt(idx, 1, rest);
     slotAt(idx, 2, decs.start); slotAt(idx, 3, decs.len);
     slotAt(idx, 4, ta);
-    flagsAt(idx, n.optional ? 1 : 0);
+    flagsAt(idx, (n.lazy ? 1 : 0) | (n.optional ? 2 : 0));
     spanAt(idx, asStart(n), asEnd(n));
     recordComments(n, idx);
     return idx;
@@ -1069,7 +1075,7 @@ function encode(program) {
     slotAt(idx, 1, rest);
     slotAt(idx, 2, decs.start); slotAt(idx, 3, decs.len);
     slotAt(idx, 4, ta);
-    flagsAt(idx, n.optional ? 1 : 0);
+    flagsAt(idx, (n.lazy ? 1 : 0) | (n.optional ? 2 : 0));
     spanAt(idx, asStart(n), asEnd(n));
     recordComments(n, idx);
     return idx;
@@ -2109,6 +2115,89 @@ function encode(program) {
     recordComments(n, idx);
     return idx;
   }
+  function enc_jsx_code_block(n) {
+    const c_body = encArr(n.body, encNode);
+    const c_render = n.render == null ? NULL : encNode(n.render);
+    const idx = alloc();
+    tagAt(idx, 171);
+    f0At(idx, c_body.len);
+    slotAt(idx, 0, c_body.start);
+    slotAt(idx, 1, c_render);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_style_sheet(n) {
+    const c_source = encStr(n.source);
+    const idx = alloc();
+    tagAt(idx, 172);
+    slotAt(idx, 0, c_source.start);
+    slotAt(idx, 1, c_source.end);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_style_element(n) {
+    const c_opening_element = n.openingElement == null ? NULL : encNode(n.openingElement);
+    const c_children = encArr(n.children, encNode);
+    const c_closing_element = n.closingElement == null ? NULL : encNode(n.closingElement);
+    const c_css = encStr(n.css);
+    const idx = alloc();
+    tagAt(idx, 173);
+    slotAt(idx, 0, c_opening_element);
+    f0At(idx, c_children.len);
+    slotAt(idx, 1, c_children.start);
+    slotAt(idx, 2, c_closing_element);
+    slotAt(idx, 3, c_css.start);
+    slotAt(idx, 4, c_css.end);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_if_expression(n) {
+    const c_test = n.test == null ? NULL : encNode(n.test);
+    const c_consequent = n.consequent == null ? NULL : encNode(n.consequent);
+    const c_alternate = n.alternate == null ? NULL : encNode(n.alternate);
+    const idx = alloc();
+    tagAt(idx, 174);
+    slotAt(idx, 0, c_test);
+    slotAt(idx, 1, c_consequent);
+    slotAt(idx, 2, c_alternate);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_for_expression(n) {
+    const c_statement = n.statement == null ? NULL : encNode(n.statement);
+    const c_empty = n.empty == null ? NULL : encNode(n.empty);
+    const idx = alloc();
+    tagAt(idx, 175);
+    slotAt(idx, 0, c_statement);
+    slotAt(idx, 1, c_empty);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_switch_expression(n) {
+    const c_statement = n.statement == null ? NULL : encNode(n.statement);
+    const idx = alloc();
+    tagAt(idx, 176);
+    slotAt(idx, 0, c_statement);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
+  function enc_jsx_try_expression(n) {
+    const c_statement = n.statement == null ? NULL : encNode(n.statement);
+    const c_pending = n.pending == null ? NULL : encNode(n.pending);
+    const idx = alloc();
+    tagAt(idx, 177);
+    slotAt(idx, 0, c_statement);
+    slotAt(idx, 1, c_pending);
+    spanAt(idx, asStart(n), asEnd(n));
+    recordComments(n, idx);
+    return idx;
+  }
   const commentsByIdx = new Map();
   function encNode(n) {
     if (n == null) return NULL;
@@ -2292,6 +2381,13 @@ function encode(program) {
       case "JSXEmptyExpression": return enc_jsx_empty_expression(n);
       case "JSXText": return enc_jsx_text(n);
       case "JSXSpreadChild": return enc_jsx_spread_child(n);
+      case "JSXCodeBlock": return enc_jsx_code_block(n);
+      case "StyleSheet": return enc_style_sheet(n);
+      case "JSXStyleElement": return enc_jsx_style_element(n);
+      case "JSXIfExpression": return enc_jsx_if_expression(n);
+      case "JSXForExpression": return enc_jsx_for_expression(n);
+      case "JSXSwitchExpression": return enc_jsx_switch_expression(n);
+      case "JSXTryExpression": return enc_jsx_try_expression(n);
       default: throw new Error("yuku-codegen: unsupported ESTree node type: " + n.type);
     }
   }

--- a/npm/yuku-parser-wasm/README.md
+++ b/npm/yuku-parser-wasm/README.md
@@ -25,7 +25,7 @@ Options:
 
 | Option                       | Default    | Description                               |
 | ---------------------------- | ---------- | ----------------------------------------- |
-| `lang`                       | `"js"`     | `"js" \| "ts" \| "jsx" \| "tsx" \| "dts"` |
+| `lang`                       | `"js"`     | `"js" \| "ts" \| "jsx" \| "tsx" \| "dts" \| "tsrx"` |
 | `sourceType`                 | `"module"` | `"module" \| "script"`                    |
 | `preserveParens`             | `true`     | Keep `ParenthesizedExpression` nodes      |
 | `allowReturnOutsideFunction` | `false`    | Allow top-level `return`                  |

--- a/npm/yuku-parser-wasm/decode.js
+++ b/npm/yuku-parser-wasm/decode.js
@@ -84,7 +84,7 @@ _ck("SwitchStatement", ["discriminant", "cases"]);
 _ck("SwitchCase", ["test", "consequent"]);
 _ck("ForStatement", ["init", "test", "update", "body"]);
 _ck("ForInStatement", ["left", "right", "body"]);
-_ck("ForOfStatement", ["left", "right", "body"]);
+_ck("ForOfStatement", ["left", "right", "body", "index", "key"]);
 _ck("WhileStatement", ["test", "body"]);
 _ck("DoWhileStatement", ["body", "test"]);
 _ck("BreakStatement", ["label"]);
@@ -94,7 +94,7 @@ _ck("WithStatement", ["object", "body"]);
 _ck("ReturnStatement", ["argument"]);
 _ck("ThrowStatement", ["argument"]);
 _ck("TryStatement", ["block", "handler", "finalizer"]);
-_ck("CatchClause", ["param", "body"]);
+_ck("CatchClause", ["param", "resetParam", "body"]);
 _ck("DebuggerStatement", []);
 _ck("EmptyStatement", []);
 _ck("VariableDeclaration", ["declarations"]);
@@ -202,6 +202,13 @@ _ck("JSXExpressionContainer", ["expression"]);
 _ck("JSXEmptyExpression", []);
 _ck("JSXText", []);
 _ck("JSXSpreadChild", ["expression"]);
+_ck("JSXCodeBlock", ["body", "render"]);
+_ck("StyleSheet", []);
+_ck("JSXStyleElement", ["openingElement", "children", "closingElement"]);
+_ck("JSXIfExpression", ["test", "consequent", "alternate"]);
+_ck("JSXForExpression", ["statement", "empty"]);
+_ck("JSXSwitchExpression", ["statement"]);
+_ck("JSXTryExpression", ["statement", "pending"]);
 _ck("Hashbang", []);
 function buildPosMap(src, byteLen, startByte) {
   const m = new Uint32Array(byteLen - startByte + 1);
@@ -553,7 +560,7 @@ function decode(buffer, source) {
     case 50: return { type: "SwitchCase", start, end, test: f1 !== NULL ? node(f1) : null, consequent: nodeArr(f2, f0) };
     case 51: return { type: "ForStatement", start, end, init: f1 !== NULL ? node(f1) : null, test: f2 !== NULL ? node(f2) : null, update: f3 !== NULL ? node(f3) : null, body: f4 !== NULL ? node(f4) : null };
     case 52: return { type: "ForInStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null };
-    case 53: return { type: "ForOfStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null, await: !!(flags & 1) };
+    case 53: return { type: "ForOfStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null, await: !!(flags & 1), index: f4 !== NULL ? node(f4) : null, key: f5 !== NULL ? node(f5) : null };
     case 54: return { type: "WhileStatement", start, end, test: f1 !== NULL ? node(f1) : null, body: f2 !== NULL ? node(f2) : null };
     case 55: return { type: "DoWhileStatement", start, end, body: f1 !== NULL ? node(f1) : null, test: f2 !== NULL ? node(f2) : null };
     case 56: return { type: "BreakStatement", start, end, label: f1 !== NULL ? node(f1) : null };
@@ -563,7 +570,7 @@ function decode(buffer, source) {
     case 60: return { type: "ReturnStatement", start, end, argument: f1 !== NULL ? node(f1) : null };
     case 61: return { type: "ThrowStatement", start, end, argument: f1 !== NULL ? node(f1) : null };
     case 62: return { type: "TryStatement", start, end, block: f1 !== NULL ? node(f1) : null, handler: f2 !== NULL ? node(f2) : null, finalizer: f3 !== NULL ? node(f3) : null };
-    case 63: return { type: "CatchClause", start, end, param: f1 !== NULL ? node(f1) : null, body: f2 !== NULL ? node(f2) : null };
+    case 63: return { type: "CatchClause", start, end, param: f1 !== NULL ? node(f1) : null, resetParam: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null };
     case 64: return { type: "DebuggerStatement", start, end };
     case 65: return { type: "EmptyStatement", start, end };
     case 66: { const r = { type: "VariableDeclaration", start, end, kind: VAR_KINDS[flags & 7], declarations: nodeArr(f1, f0) }; if (_isTs) { r.declare = !!(flags & 8); } return r; }
@@ -578,9 +585,10 @@ function decode(buffer, source) {
       const el = nodeArrHoles(f1, f0);
       if (f2 !== NULL) el.push(node(f2));
       const r = { type: "ArrayPattern", start, end, elements: el };
+      if (flags & 1) r.lazy = true;
       if (_isTs) {
         r.decorators = nodeArr(f3, f4);
-        r.optional = !!(flags & 1);
+        r.optional = !!(flags & 2);
         r.typeAnnotation = f5 !== NULL ? node(f5) : null;
       }
       return r;
@@ -589,9 +597,10 @@ function decode(buffer, source) {
       const pr = nodeArr(f1, f0);
       if (f2 !== NULL) pr.push(node(f2));
       const r = { type: "ObjectPattern", start, end, properties: pr };
+      if (flags & 1) r.lazy = true;
       if (_isTs) {
         r.decorators = nodeArr(f3, f4);
-        r.optional = !!(flags & 1);
+        r.optional = !!(flags & 2);
         r.typeAnnotation = f5 !== NULL ? node(f5) : null;
       }
       return r;
@@ -774,6 +783,13 @@ function decode(buffer, source) {
       return { type: "JSXText", start, end, value: t, raw: t };
     }
     case 170: return { type: "JSXSpreadChild", start, end, expression: f1 !== NULL ? node(f1) : null };
+    case 171: return { type: "JSXCodeBlock", start, end, body: nodeArr(f1, f0), render: f2 !== NULL ? node(f2) : null };
+    case 172: return { type: "StyleSheet", start, end, source: str(f1, f2) };
+    case 173: return { type: "JSXStyleElement", start, end, openingElement: f1 !== NULL ? node(f1) : null, children: nodeArr(f2, f0), closingElement: f3 !== NULL ? node(f3) : null, css: str(f4, f5) };
+    case 174: return { type: "JSXIfExpression", start, end, test: f1 !== NULL ? node(f1) : null, consequent: f2 !== NULL ? node(f2) : null, alternate: f3 !== NULL ? node(f3) : null };
+    case 175: return { type: "JSXForExpression", start, end, statement: f1 !== NULL ? node(f1) : null, empty: f2 !== NULL ? node(f2) : null };
+    case 176: return { type: "JSXSwitchExpression", start, end, statement: f1 !== NULL ? node(f1) : null };
+    case 177: return { type: "JSXTryExpression", start, end, statement: f1 !== NULL ? node(f1) : null, pending: f2 !== NULL ? node(f2) : null };
     }
   }
   const node = _attached ? nodeWithComments : _decode;

--- a/npm/yuku-parser-wasm/index.d.ts
+++ b/npm/yuku-parser-wasm/index.d.ts
@@ -110,6 +110,7 @@ export function walk<T extends Node, S = unknown>(root: T, visitors: Visitors<S>
  * Resolves a {@link SourceLang} from a file path's extension.
  *
  * - `.d.ts`, `.d.mts`, `.d.cts` → `"dts"`
+ * - `.tsrx` → `"tsrx"`
  * - `.tsx` → `"tsx"`
  * - `.ts`, `.mts`, `.cts` → `"ts"`
  * - `.jsx` → `"jsx"`

--- a/npm/yuku-parser-wasm/index.js
+++ b/npm/yuku-parser-wasm/index.js
@@ -20,7 +20,7 @@ async function instantiate() {
 const { memory, alloc, free, parse: wasmParse } = (await instantiate()).exports;
 const encoder = new TextEncoder();
 
-const LANGS = { js: 0, ts: 1, jsx: 2, tsx: 3, dts: 4 };
+const LANGS = { js: 0, ts: 1, jsx: 2, tsx: 3, dts: 4, tsrx: 5 };
 
 function packFlags(o = {}) {
   let f = (LANGS[o.lang] ?? 0) << 1;
@@ -52,6 +52,7 @@ export function parse(source, options) {
 
 export function langFromPath(path) {
   if (path.endsWith(".d.ts") || path.endsWith(".d.mts") || path.endsWith(".d.cts")) return "dts";
+  if (path.endsWith(".tsrx")) return "tsrx";
   if (path.endsWith(".tsx")) return "tsx";
   if (path.endsWith(".ts") || path.endsWith(".mts") || path.endsWith(".cts")) return "ts";
   if (path.endsWith(".jsx")) return "jsx";

--- a/npm/yuku-parser-wasm/package.json
+++ b/npm/yuku-parser-wasm/package.json
@@ -39,6 +39,7 @@
     "tokenizer",
     "ts",
     "tsx",
+    "tsrx",
     "typescript",
     "wasm",
     "webassembly",

--- a/npm/yuku-parser/README.md
+++ b/npm/yuku-parser/README.md
@@ -121,7 +121,7 @@ const result = parse(source, {
 | Option                       | Values                                    | Default    | Description                                                                                                                  |
 | ---------------------------- | ----------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `sourceType`                 | `"module"`, `"script"`                    | `"module"` | Module mode enables `import`/`export`, `import.meta`, top-level `await`, and strict mode.                                    |
-| `lang`                       | `"js"`, `"ts"`, `"jsx"`, `"tsx"`, `"dts"` | `"js"`     | Language variant controls which syntax extensions are enabled.                                                               |
+| `lang`                       | `"js"`, `"ts"`, `"jsx"`, `"tsx"`, `"dts"`, `"tsrx"` | `"js"`     | Language variant controls which syntax extensions are enabled.                                                     |
 | `preserveParens`             | `true`, `false`                           | `true`     | Keep `ParenthesizedExpression` nodes in the AST. When false, parentheses are stripped and only the inner expression is kept. |
 | `allowReturnOutsideFunction` | `true`, `false`                           | `false`    | Allow `return` statements outside of functions, at the top level.                                                            |
 | `semanticErrors`             | `true`, `false`                           | `false`    | Run semantic analysis and report semantic errors alongside syntax errors.                                                    |

--- a/npm/yuku-parser/decode.js
+++ b/npm/yuku-parser/decode.js
@@ -84,7 +84,7 @@ _ck("SwitchStatement", ["discriminant", "cases"]);
 _ck("SwitchCase", ["test", "consequent"]);
 _ck("ForStatement", ["init", "test", "update", "body"]);
 _ck("ForInStatement", ["left", "right", "body"]);
-_ck("ForOfStatement", ["left", "right", "body"]);
+_ck("ForOfStatement", ["left", "right", "body", "index", "key"]);
 _ck("WhileStatement", ["test", "body"]);
 _ck("DoWhileStatement", ["body", "test"]);
 _ck("BreakStatement", ["label"]);
@@ -94,7 +94,7 @@ _ck("WithStatement", ["object", "body"]);
 _ck("ReturnStatement", ["argument"]);
 _ck("ThrowStatement", ["argument"]);
 _ck("TryStatement", ["block", "handler", "finalizer"]);
-_ck("CatchClause", ["param", "body"]);
+_ck("CatchClause", ["param", "resetParam", "body"]);
 _ck("DebuggerStatement", []);
 _ck("EmptyStatement", []);
 _ck("VariableDeclaration", ["declarations"]);
@@ -202,6 +202,13 @@ _ck("JSXExpressionContainer", ["expression"]);
 _ck("JSXEmptyExpression", []);
 _ck("JSXText", []);
 _ck("JSXSpreadChild", ["expression"]);
+_ck("JSXCodeBlock", ["body", "render"]);
+_ck("StyleSheet", []);
+_ck("JSXStyleElement", ["openingElement", "children", "closingElement"]);
+_ck("JSXIfExpression", ["test", "consequent", "alternate"]);
+_ck("JSXForExpression", ["statement", "empty"]);
+_ck("JSXSwitchExpression", ["statement"]);
+_ck("JSXTryExpression", ["statement", "pending"]);
 _ck("Hashbang", []);
 function buildPosMap(src, byteLen, startByte) {
   const m = new Uint32Array(byteLen - startByte + 1);
@@ -553,7 +560,7 @@ function decode(buffer, source) {
     case 50: return { type: "SwitchCase", start, end, test: f1 !== NULL ? node(f1) : null, consequent: nodeArr(f2, f0) };
     case 51: return { type: "ForStatement", start, end, init: f1 !== NULL ? node(f1) : null, test: f2 !== NULL ? node(f2) : null, update: f3 !== NULL ? node(f3) : null, body: f4 !== NULL ? node(f4) : null };
     case 52: return { type: "ForInStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null };
-    case 53: return { type: "ForOfStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null, await: !!(flags & 1) };
+    case 53: return { type: "ForOfStatement", start, end, left: f1 !== NULL ? node(f1) : null, right: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null, await: !!(flags & 1), index: f4 !== NULL ? node(f4) : null, key: f5 !== NULL ? node(f5) : null };
     case 54: return { type: "WhileStatement", start, end, test: f1 !== NULL ? node(f1) : null, body: f2 !== NULL ? node(f2) : null };
     case 55: return { type: "DoWhileStatement", start, end, body: f1 !== NULL ? node(f1) : null, test: f2 !== NULL ? node(f2) : null };
     case 56: return { type: "BreakStatement", start, end, label: f1 !== NULL ? node(f1) : null };
@@ -563,7 +570,7 @@ function decode(buffer, source) {
     case 60: return { type: "ReturnStatement", start, end, argument: f1 !== NULL ? node(f1) : null };
     case 61: return { type: "ThrowStatement", start, end, argument: f1 !== NULL ? node(f1) : null };
     case 62: return { type: "TryStatement", start, end, block: f1 !== NULL ? node(f1) : null, handler: f2 !== NULL ? node(f2) : null, finalizer: f3 !== NULL ? node(f3) : null };
-    case 63: return { type: "CatchClause", start, end, param: f1 !== NULL ? node(f1) : null, body: f2 !== NULL ? node(f2) : null };
+    case 63: return { type: "CatchClause", start, end, param: f1 !== NULL ? node(f1) : null, resetParam: f2 !== NULL ? node(f2) : null, body: f3 !== NULL ? node(f3) : null };
     case 64: return { type: "DebuggerStatement", start, end };
     case 65: return { type: "EmptyStatement", start, end };
     case 66: { const r = { type: "VariableDeclaration", start, end, kind: VAR_KINDS[flags & 7], declarations: nodeArr(f1, f0) }; if (_isTs) { r.declare = !!(flags & 8); } return r; }
@@ -578,9 +585,10 @@ function decode(buffer, source) {
       const el = nodeArrHoles(f1, f0);
       if (f2 !== NULL) el.push(node(f2));
       const r = { type: "ArrayPattern", start, end, elements: el };
+      if (flags & 1) r.lazy = true;
       if (_isTs) {
         r.decorators = nodeArr(f3, f4);
-        r.optional = !!(flags & 1);
+        r.optional = !!(flags & 2);
         r.typeAnnotation = f5 !== NULL ? node(f5) : null;
       }
       return r;
@@ -589,9 +597,10 @@ function decode(buffer, source) {
       const pr = nodeArr(f1, f0);
       if (f2 !== NULL) pr.push(node(f2));
       const r = { type: "ObjectPattern", start, end, properties: pr };
+      if (flags & 1) r.lazy = true;
       if (_isTs) {
         r.decorators = nodeArr(f3, f4);
-        r.optional = !!(flags & 1);
+        r.optional = !!(flags & 2);
         r.typeAnnotation = f5 !== NULL ? node(f5) : null;
       }
       return r;
@@ -774,6 +783,13 @@ function decode(buffer, source) {
       return { type: "JSXText", start, end, value: t, raw: t };
     }
     case 170: return { type: "JSXSpreadChild", start, end, expression: f1 !== NULL ? node(f1) : null };
+    case 171: return { type: "JSXCodeBlock", start, end, body: nodeArr(f1, f0), render: f2 !== NULL ? node(f2) : null };
+    case 172: return { type: "StyleSheet", start, end, source: str(f1, f2) };
+    case 173: return { type: "JSXStyleElement", start, end, openingElement: f1 !== NULL ? node(f1) : null, children: nodeArr(f2, f0), closingElement: f3 !== NULL ? node(f3) : null, css: str(f4, f5) };
+    case 174: return { type: "JSXIfExpression", start, end, test: f1 !== NULL ? node(f1) : null, consequent: f2 !== NULL ? node(f2) : null, alternate: f3 !== NULL ? node(f3) : null };
+    case 175: return { type: "JSXForExpression", start, end, statement: f1 !== NULL ? node(f1) : null, empty: f2 !== NULL ? node(f2) : null };
+    case 176: return { type: "JSXSwitchExpression", start, end, statement: f1 !== NULL ? node(f1) : null };
+    case 177: return { type: "JSXTryExpression", start, end, statement: f1 !== NULL ? node(f1) : null, pending: f2 !== NULL ? node(f2) : null };
     }
   }
   const node = _attached ? nodeWithComments : _decode;

--- a/npm/yuku-parser/index.d.ts
+++ b/npm/yuku-parser/index.d.ts
@@ -110,6 +110,7 @@ export function walk<T extends Node, S = unknown>(root: T, visitors: Visitors<S>
  * Resolves a {@link SourceLang} from a file path's extension.
  *
  * - `.d.ts`, `.d.mts`, `.d.cts` → `"dts"`
+ * - `.tsrx` → `"tsrx"`
  * - `.tsx` → `"tsx"`
  * - `.ts`, `.mts`, `.cts` → `"ts"`
  * - `.jsx` → `"jsx"`

--- a/npm/yuku-parser/index.js
+++ b/npm/yuku-parser/index.js
@@ -9,6 +9,7 @@ export function parse(source, options) {
 
 export function langFromPath(path) {
   if (path.endsWith(".d.ts") || path.endsWith(".d.mts") || path.endsWith(".d.cts")) return "dts";
+  if (path.endsWith(".tsrx")) return "tsrx";
   if (path.endsWith(".tsx")) return "tsx";
   if (path.endsWith(".ts") || path.endsWith(".mts") || path.endsWith(".cts")) return "ts";
   if (path.endsWith(".jsx")) return "jsx";

--- a/npm/yuku-parser/package.json
+++ b/npm/yuku-parser/package.json
@@ -53,6 +53,7 @@
     "tokenizer",
     "ts",
     "tsx",
+    "tsrx",
     "typescript"
   ]
 }

--- a/npm/yuku-types/index.d.ts
+++ b/npm/yuku-types/index.d.ts
@@ -4,7 +4,7 @@ type SourceType = "script" | "module";
 type ModuleKind = SourceType;
 
 /** Language variant of the source code. */
-type SourceLang = "js" | "ts" | "jsx" | "tsx" | "dts";
+type SourceLang = "js" | "ts" | "jsx" | "tsx" | "dts" | "tsrx";
 /** Whether a comment came from a line or block source comment. */
 type CommentType = "Line" | "Block";
 
@@ -296,6 +296,7 @@ type Literal =
 interface ArrayPattern extends BaseNode {
   type: "ArrayPattern";
   elements: Array<BindingPattern | RestElement | null>;
+  lazy?: boolean;
   decorators?: Decorator[];
   optional?: boolean;
   typeAnnotation?: TSTypeAnnotation | null;
@@ -304,6 +305,7 @@ interface ArrayPattern extends BaseNode {
 interface ObjectPattern extends BaseNode {
   type: "ObjectPattern";
   properties: Array<BindingProperty | RestElement>;
+  lazy?: boolean;
   decorators?: Decorator[];
   optional?: boolean;
   typeAnnotation?: TSTypeAnnotation | null;
@@ -558,7 +560,7 @@ interface Directive extends BaseNode {
 
 interface BlockStatement extends BaseNode {
   type: "BlockStatement";
-  body: (Statement | Directive)[];
+  body: (Statement | Directive | Expression)[];
 }
 
 interface IfStatement extends BaseNode {
@@ -604,6 +606,8 @@ interface ForOfStatement extends BaseNode {
   right: Expression;
   body: Statement;
   await: boolean;
+  index: IdentifierReference | null;
+  key: Expression | null;
 }
 
 interface WhileStatement extends BaseNode {
@@ -660,6 +664,7 @@ interface TryStatement extends BaseNode {
 interface CatchClause extends BaseNode {
   type: "CatchClause";
   param: BindingPattern | null;
+  resetParam: BindingPattern | null;
   body: BlockStatement;
 }
 
@@ -691,7 +696,7 @@ interface FunctionDeclaration extends BaseNode {
   generator: boolean;
   async: boolean;
   params: FunctionParameter[];
-  body: BlockStatement | null;
+  body: BlockStatement | JSXCodeBlock | null;
   expression: false;
   declare?: boolean;
   typeParameters?: TSTypeParameterDeclaration | null;
@@ -704,7 +709,7 @@ interface FunctionExpression extends BaseNode {
   generator: boolean;
   async: boolean;
   params: FunctionParameter[];
-  body: BlockStatement | null;
+  body: BlockStatement | JSXCodeBlock | null;
   expression: false;
   declare?: boolean;
   typeParameters?: TSTypeParameterDeclaration | null;
@@ -901,7 +906,7 @@ type ClassElement =
 interface ImportDeclaration extends BaseNode {
   type: "ImportDeclaration";
   specifiers: ImportDeclarationSpecifier[];
-  source: StringLiteral;
+  source: StringLiteral | IdentifierReference;
   phase: ImportPhase | null;
   attributes: ImportAttribute[];
   importKind?: ImportOrExportKind;
@@ -1035,7 +1040,12 @@ interface JSXAttribute extends BaseNode {
 
 type JSXAttributeName = JSXIdentifier | JSXNamespacedName;
 
-type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElement | JSXFragment;
+type JSXAttributeValue =
+  | StringLiteral
+  | JSXExpressionContainer
+  | JSXElement
+  | JSXFragment
+  | JSXStyleElement;
 
 interface JSXSpreadAttribute extends BaseNode {
   type: "JSXSpreadAttribute";
@@ -1064,11 +1074,73 @@ interface JSXSpreadChild extends BaseNode {
   expression: Expression;
 }
 
-type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpression;
+interface JSXCodeBlock extends BaseNode {
+  type: "JSXCodeBlock";
+  body: Statement[];
+  render: Node | null;
+}
+
+interface StyleSheet extends BaseNode {
+  type: "StyleSheet";
+  source: string;
+}
+
+interface JSXStyleElement extends BaseNode {
+  type: "JSXStyleElement";
+  openingElement: JSXOpeningElement;
+  children: StyleSheet[];
+  closingElement: JSXClosingElement | null;
+  css: string;
+}
+
+interface JSXIfExpression extends BaseNode {
+  type: "JSXIfExpression";
+  test: Expression;
+  consequent: BlockStatement;
+  alternate: BlockStatement | JSXIfExpression | null;
+  statementType?: "IfStatement";
+}
+
+interface JSXForExpression extends BaseNode {
+  type: "JSXForExpression";
+  statement: ForStatement | ForInStatement | ForOfStatement;
+  empty: BlockStatement | null;
+  statementType?: "ForStatement" | "ForInStatement" | "ForOfStatement";
+}
+
+interface JSXSwitchExpression extends BaseNode {
+  type: "JSXSwitchExpression";
+  statement: SwitchStatement;
+  statementType?: "SwitchStatement";
+}
+
+interface JSXTryExpression extends BaseNode {
+  type: "JSXTryExpression";
+  statement: TryStatement;
+  pending: BlockStatement | null;
+  statementType?: "TryStatement";
+}
+
+type JSXElementName =
+  | JSXIdentifier
+  | JSXNamespacedName
+  | JSXMemberExpression
+  | JSXExpressionContainer;
 
 type JSXTagName = JSXElementName;
 
-type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;
+type JSXChild =
+  | JSXText
+  | JSXElement
+  | JSXFragment
+  | JSXStyleElement
+  | JSXExpressionContainer
+  | JSXSpreadChild
+  | JSXCodeBlock
+  | JSXIfExpression
+  | JSXForExpression
+  | JSXSwitchExpression
+  | JSXTryExpression;
 
 // TypeScript types
 
@@ -1618,7 +1690,13 @@ type Expression =
   | TSNonNullExpression
   | TSInstantiationExpression
   | JSXElement
-  | JSXFragment;
+  | JSXFragment
+  | JSXStyleElement
+  | JSXCodeBlock
+  | JSXIfExpression
+  | JSXForExpression
+  | JSXSwitchExpression
+  | JSXTryExpression;
 
 type Statement =
   | ExpressionStatement
@@ -1696,6 +1774,13 @@ type Node =
   | JSXEmptyExpression
   | JSXText
   | JSXSpreadChild
+  | JSXCodeBlock
+  | StyleSheet
+  | JSXStyleElement
+  | JSXIfExpression
+  | JSXForExpression
+  | JSXSwitchExpression
+  | JSXTryExpression
   | TSTypeAnnotation
   | TSType
   | TSTypeParameter
@@ -1886,6 +1971,13 @@ export type {
   JSXEmptyExpression,
   JSXText,
   JSXSpreadChild,
+  JSXCodeBlock,
+  StyleSheet,
+  JSXStyleElement,
+  JSXIfExpression,
+  JSXForExpression,
+  JSXSwitchExpression,
+  JSXTryExpression,
   JSXTagName,
   JSXElementName,
   JSXChild,

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -74,13 +74,14 @@ pub const Lang = enum {
     jsx,
     tsx,
     dts,
+    tsrx,
 
     /// Determines the language variant based on the file extension.
     ///
-    /// `.d.ts`, `.d.mts`, `.d.cts` resolve to `dts`. `.tsx` resolves to
-    /// `tsx`. `.ts`, `.mts`, `.cts` resolve to `ts`. `.jsx` resolves to
-    /// `jsx`. Anything else (including `.js`, `.mjs`, `.cjs`) resolves to
-    /// `js`.
+    /// `.d.ts`, `.d.mts`, `.d.cts` resolve to `dts`. `.tsrx` resolves to
+    /// `tsrx`. `.tsx` resolves to `tsx`. `.ts`, `.mts`, `.cts` resolve to
+    /// `ts`. `.jsx` resolves to `jsx`. Anything else (including `.js`,
+    /// `.mjs`, `.cjs`) resolves to `js`.
     pub fn fromPath(path: []const u8) Lang {
         if (std.mem.endsWith(u8, path, ".d.ts") or
             std.mem.endsWith(u8, path, ".d.mts") or
@@ -89,6 +90,7 @@ pub const Lang = enum {
             return .dts;
         }
 
+        if (std.mem.endsWith(u8, path, ".tsrx")) return .tsrx;
         if (std.mem.endsWith(u8, path, ".tsx")) return .tsx;
 
         if (std.mem.endsWith(u8, path, ".ts") or
@@ -184,7 +186,7 @@ pub const Tree = struct {
     strings: StringPool = .{},
     /// Source type (script or module).
     source_type: SourceType = .module,
-    /// Language variant (js, ts, jsx, tsx, dts).
+    /// Language variant (js, ts, jsx, tsx, dts, tsrx).
     lang: Lang = .js,
 
     /// Creates a tree for parsing or transforming source code.
@@ -214,11 +216,16 @@ pub const Tree = struct {
     }
 
     pub inline fn isTs(self: *const Tree) bool {
-        return self.lang == .ts or self.lang == .tsx or self.lang == .dts;
+        return self.lang == .ts or self.lang == .tsx or
+            self.lang == .dts or self.lang == .tsrx;
     }
 
     pub inline fn isJsx(self: *const Tree) bool {
-        return self.lang == .tsx or self.lang == .jsx;
+        return self.lang == .tsx or self.lang == .jsx or self.lang == .tsrx;
+    }
+
+    pub inline fn isTsrx(self: *const Tree) bool {
+        return self.lang == .tsrx;
     }
 
     pub inline fn isModule(self: *const Tree) bool {
@@ -1200,6 +1207,10 @@ pub const ForOfStatement = struct {
     body: NodeIndex,
     /// true for `for await (...)`.
     await: bool,
+    /// `identifier_reference`. `.null` when omitted.
+    index: NodeIndex = .null,
+    /// any expression. `.null` when omitted.
+    key: NodeIndex = .null,
 };
 
 /// A `break` statement, optionally targeting a label.
@@ -1312,6 +1323,8 @@ pub const TryStatement = struct {
 pub const CatchClause = struct {
     /// any binding pattern. `.null` for `catch { }` with no binding.
     param: NodeIndex,
+    /// TSRX reset binding pattern. `.null` when omitted.
+    reset_param: NodeIndex = .null,
     /// `block_statement`
     body: NodeIndex,
 };
@@ -1663,6 +1676,8 @@ pub const ArrayPattern = struct {
     elements: IndexRange,
     /// `binding_rest_element`. `.null` when no rest element is present.
     rest: NodeIndex,
+    /// True when written as TSRX lazy destructuring `&[...]`.
+    lazy: bool = false,
     /// `decorator[]`. Decorators on a parameter binding (legacy
     /// `experimentalDecorators`).
     decorators: IndexRange = .empty,
@@ -1686,6 +1701,8 @@ pub const ObjectPattern = struct {
     properties: IndexRange,
     /// `binding_rest_element`. `.null` when no rest element is present.
     rest: NodeIndex,
+    /// True when written as TSRX lazy destructuring `&{...}`.
+    lazy: bool = false,
     /// `decorator[]`. Decorators on a parameter binding (legacy
     /// `experimentalDecorators`).
     decorators: IndexRange = .empty,
@@ -1904,7 +1921,7 @@ pub const Function = struct {
     declare: bool = false,
     /// `formal_parameters`
     params: NodeIndex,
-    /// `function_body`. `.null` for body-less declarations and signatures.
+    /// `function_body` or `jsx_code_block`. `.null` for body-less declarations and signatures.
     body: NodeIndex,
     /// `ts_type_parameter_declaration`. `.null` when absent.
     type_parameters: NodeIndex = .null,
@@ -2252,7 +2269,7 @@ pub const ImportDeclaration = struct {
     /// `import_specifier`, `import_default_specifier`, or
     /// `import_namespace_specifier`. Empty for side-effect-only imports.
     specifiers: IndexRange,
-    /// `string_literal`
+    /// `string_literal`, or TSRX `identifier_reference`
     source: NodeIndex,
     /// `import_attribute[]`
     attributes: IndexRange,
@@ -3851,7 +3868,7 @@ pub const TSExternalModuleReference = struct {
 pub const JSXElement = struct {
     /// `jsx_opening_element`
     opening_element: NodeIndex,
-    /// `jsx_text`, `jsx_expression_container`, `jsx_spread_child`, `jsx_element`, or `jsx_fragment`
+    /// JSX child nodes.
     children: IndexRange,
     /// `jsx_closing_element`. `.null` for self-closing tags like `<Foo />`.
     closing_element: NodeIndex,
@@ -3904,7 +3921,7 @@ pub const JSXClosingElement = struct {
 pub const JSXFragment = struct {
     /// `jsx_opening_fragment`
     opening_fragment: NodeIndex,
-    /// `jsx_text`, `jsx_expression_container`, `jsx_spread_child`, `jsx_element`, or `jsx_fragment`
+    /// JSX child nodes.
     children: IndexRange,
     /// `jsx_closing_fragment`
     closing_fragment: NodeIndex,
@@ -4025,6 +4042,106 @@ pub const JSXText = struct {
 pub const JSXSpreadChild = struct {
     /// any expression
     expression: NodeIndex,
+};
+
+/// A TSRX `@{ ... }` statement container inside JSX children.
+///
+/// ## Example
+/// ```tsrx
+/// <View>@{ const value = 1; }</View>
+/// //    ^^^^^^^^^^^^^^^^^^^^^ body
+/// ```
+pub const JSXCodeBlock = struct {
+    /// statement[]
+    body: IndexRange,
+    /// render output node. `.null` when the block only contains statements.
+    render: NodeIndex = .null,
+};
+
+/// Raw CSS captured from a TSRX `<style>` element.
+///
+/// ## Example
+/// ```tsrx
+/// <style>.card { color: red; }</style>
+/// //     ^^^^^^^^^^^^^^^^^^^^^ source
+/// ```
+pub const StyleSheet = struct {
+    source: String = .empty,
+};
+
+/// A TSRX raw `<style>` element.
+///
+/// ## Example
+/// ```tsrx
+/// <style>.card { color: red; }</style>
+/// //      ^^^^^^^^^^^^^^^^^^^ children
+/// ```
+pub const JSXStyleElement = struct {
+    /// `jsx_opening_element`
+    opening_element: NodeIndex,
+    /// `style_sheet`.
+    children: IndexRange,
+    /// `jsx_closing_element`. `.null` for self-closing authored input.
+    closing_element: NodeIndex,
+    /// raw CSS source text between the opening and closing tags.
+    css: String = .empty,
+};
+
+/// A TSRX `@if` template control-flow expression.
+///
+/// ## Example
+/// ```tsrx
+/// @if (ready) { <span /> }
+/// //  ^^^^^ test
+/// ```
+pub const JSXIfExpression = struct {
+    /// any expression
+    @"test": NodeIndex,
+    /// `block_statement`
+    consequent: NodeIndex,
+    /// `block_statement` or `jsx_if_expression`. `.null` when there is no `@else`.
+    alternate: NodeIndex,
+};
+
+/// A TSRX `@for` template control-flow expression.
+///
+/// ## Example
+/// ```tsrx
+/// @for (const item of items) { <Row /> } @empty { <Empty /> }
+/// //   ^^^^^^^^^^^^^^^^^^^^^ statement
+/// //                                    ^^^^^^^^^^^^^^^^^^^ empty
+/// ```
+pub const JSXForExpression = struct {
+    /// `for_statement`, `for_in_statement`, or `for_of_statement`
+    statement: NodeIndex,
+    /// `block_statement`. `.null` when there is no `@empty` clause.
+    empty: NodeIndex = .null,
+};
+
+/// A TSRX `@switch` template control-flow expression.
+///
+/// ## Example
+/// ```tsrx
+/// @switch (kind) { @case "ok": { <Ok /> } }
+/// //       ^^^^ statement.discriminant
+/// ```
+pub const JSXSwitchExpression = struct {
+    /// `switch_statement`
+    statement: NodeIndex,
+};
+
+/// A TSRX `@try` template control-flow expression.
+///
+/// ## Example
+/// ```tsrx
+/// @try { <Ready /> } @catch (error) { <Error /> }
+/// //   ^ statement.block
+/// ```
+pub const JSXTryExpression = struct {
+    /// `try_statement`
+    statement: NodeIndex,
+    /// `block_statement`. `.null` when there is no `@pending` clause.
+    pending: NodeIndex = .null,
 };
 
 pub const NodeData = union(enum) {
@@ -4203,6 +4320,13 @@ pub const NodeData = union(enum) {
     jsx_empty_expression: JSXEmptyExpression,
     jsx_text: JSXText,
     jsx_spread_child: JSXSpreadChild,
+    jsx_code_block: JSXCodeBlock,
+    style_sheet: StyleSheet,
+    jsx_style_element: JSXStyleElement,
+    jsx_if_expression: JSXIfExpression,
+    jsx_for_expression: JSXForExpression,
+    jsx_switch_expression: JSXSwitchExpression,
+    jsx_try_expression: JSXTryExpression,
 
     /// True when this node produces a value at runtime.
     ///
@@ -4249,6 +4373,12 @@ pub const NodeData = union(enum) {
             .ts_instantiation_expression,
             .jsx_element,
             .jsx_fragment,
+            .jsx_style_element,
+            .jsx_code_block,
+            .jsx_if_expression,
+            .jsx_for_expression,
+            .jsx_switch_expression,
+            .jsx_try_expression,
             => true,
             .function => |f| f.type == .function_expression or
                 f.type == .ts_empty_body_function_expression,

--- a/src/parser/codegen/printer.zig
+++ b/src/parser/codegen/printer.zig
@@ -1034,6 +1034,18 @@ fn Printer(comptime cfg: Config) type {
             if (wrap_async) try self.writeByte(')');
             try self.writeStr(" of ");
             try self.emitValue(s.right);
+            if (s.index != .null or s.key != .null) {
+                try self.writeStr("; ");
+                if (s.index != .null) {
+                    try self.writeStr("index ");
+                    try self.emit(s.index);
+                    if (s.key != .null) try self.writeStr("; ");
+                }
+                if (s.key != .null) {
+                    try self.writeStr("key ");
+                    try self.emit(s.key);
+                }
+            }
             try self.writeByte(')');
             try self.space();
             try self.emitStmt(s.body);
@@ -1101,6 +1113,10 @@ fn Printer(comptime cfg: Config) type {
                 try self.space();
                 try self.writeByte('(');
                 try self.emit(c.param);
+                if (c.reset_param != .null) {
+                    try self.writeStr(", ");
+                    try self.emit(c.reset_param);
+                }
                 try self.writeByte(')');
             }
             try self.space();
@@ -1677,6 +1693,7 @@ fn Printer(comptime cfg: Config) type {
         fn emit_array_pattern(self: *Self, p: *const ast.ArrayPattern) Error!void {
             const definite = self.takeDefinite();
             if (comptime !strip_ts) try self.printDecorators(p.decorators);
+            if (p.lazy) try self.writeByte('&');
             try self.writeByte('[');
             const list = self.tree.extra(p.elements);
             for (list, 0..) |x, i| {
@@ -1697,6 +1714,7 @@ fn Printer(comptime cfg: Config) type {
         fn emit_object_pattern(self: *Self, p: *const ast.ObjectPattern) Error!void {
             const definite = self.takeDefinite();
             if (comptime !strip_ts) try self.printDecorators(p.decorators);
+            if (p.lazy) try self.writeByte('&');
             try self.writeByte('{');
             const list = self.tree.extra(p.properties);
             const has_any = list.len > 0 or p.rest != .null;
@@ -2817,6 +2835,20 @@ fn Printer(comptime cfg: Config) type {
             if (e.closing_element != .null) try self.emit(e.closing_element);
         }
 
+        fn emit_jsx_style_element(self: *Self, e: *const ast.JSXStyleElement) Error!void {
+            try self.emit(e.opening_element);
+            if (e.css.len() > 0) {
+                try self.writeString(e.css);
+            } else {
+                for (self.tree.extra(e.children)) |c| try self.emit(c);
+            }
+            if (e.closing_element != .null) try self.emit(e.closing_element);
+        }
+
+        fn emit_style_sheet(self: *Self, s: *const ast.StyleSheet) Error!void {
+            try self.writeString(s.source);
+        }
+
         fn emit_jsx_opening_element(self: *Self, o: *const ast.JSXOpeningElement) Error!void {
             try self.writeByte('<');
             try self.emit(o.name);
@@ -2890,7 +2922,15 @@ fn Printer(comptime cfg: Config) type {
         fn emit_jsx_empty_expression(_: *Self, _: *const ast.JSXEmptyExpression) Error!void {}
 
         fn emit_jsx_text(self: *Self, t: *const ast.JSXText) Error!void {
-            try self.writeString(t.value);
+            const text = self.tree.string(t.value);
+            for (text) |c| {
+                switch (c) {
+                    '&' => try self.writeStr("&amp;"),
+                    '<' => try self.writeStr("&lt;"),
+                    '{' => try self.writeStr("&#123;"),
+                    else => try self.writeByte(c),
+                }
+            }
         }
 
         fn emit_jsx_spread_child(self: *Self, c: *const ast.JSXSpreadChild) Error!void {
@@ -2898,6 +2938,143 @@ fn Printer(comptime cfg: Config) type {
             try self.writeStr("...");
             try self.emit(c.expression);
             try self.writeByte('}');
+        }
+
+        fn emit_jsx_code_block(self: *Self, c: *const ast.JSXCodeBlock) Error!void {
+            try self.writeByte('@');
+            try self.writeByte('{');
+
+            const body = self.tree.extra(c.body);
+            const has_render = c.render != .null;
+            if (body.len > 0 or has_render) {
+                const cur = self.cursor();
+                self.indent_depth += 1;
+                try self.newline();
+                const after_indent = self.mark();
+
+                try self.printStmtList(c.body, false);
+                if (has_render) {
+                    if (body.len > 0) {
+                        try self.flushSemi();
+                        try self.newline();
+                    }
+                    try self.emit(c.render);
+                }
+
+                self.indent_depth -= 1;
+                if (self.mark() == after_indent) {
+                    self.restore(cur);
+                } else {
+                    self.pending_semi = false;
+                    try self.newline();
+                }
+            }
+
+            try self.writeByte('}');
+        }
+
+        fn emit_jsx_if_expression(self: *Self, i: *const ast.JSXIfExpression) Error!void {
+            try self.writeStr("@if");
+            try self.space();
+            try self.writeByte('(');
+            try self.emit(i.@"test");
+            try self.writeByte(')');
+            try self.space();
+            try self.emit(i.consequent);
+
+            if (i.alternate != .null) {
+                try self.space();
+                try self.writeStr("@else ");
+                try self.emit(i.alternate);
+            }
+        }
+
+        fn emit_jsx_for_expression(self: *Self, f: *const ast.JSXForExpression) Error!void {
+            try self.writeByte('@');
+            try self.emit(f.statement);
+
+            if (f.empty != .null) {
+                try self.space();
+                try self.writeStr("@empty ");
+                try self.emit(f.empty);
+            }
+        }
+
+        fn emit_jsx_switch_expression(
+            self: *Self,
+            s: *const ast.JSXSwitchExpression,
+        ) Error!void {
+            const statement = self.nodeData(s.statement).switch_statement;
+
+            try self.writeStr("@switch");
+            try self.space();
+            try self.writeByte('(');
+            try self.emit(statement.discriminant);
+            try self.writeByte(')');
+            try self.space();
+            try self.writeByte('{');
+
+            const cases = self.tree.extra(statement.cases);
+            if (cases.len > 0) {
+                self.indent_depth += 1;
+                for (cases) |case_node| {
+                    try self.newline();
+                    try self.emitTsrxSwitchCase(case_node);
+                }
+                self.indent_depth -= 1;
+                try self.newline();
+            }
+
+            try self.writeByte('}');
+        }
+
+        fn emitTsrxSwitchCase(self: *Self, idx: NodeIndex) Error!void {
+            const case_node = self.nodeData(idx).switch_case;
+            if (case_node.@"test" == .null) {
+                try self.writeStr("@default");
+            } else {
+                try self.writeStr("@case ");
+                try self.emit(case_node.@"test");
+            }
+
+            try self.writeStr(": ");
+            try self.printBlock(case_node.consequent, false);
+        }
+
+        fn emit_jsx_try_expression(self: *Self, t: *const ast.JSXTryExpression) Error!void {
+            const statement = self.nodeData(t.statement).try_statement;
+
+            try self.writeStr("@try ");
+            try self.emit(statement.block);
+
+            if (t.pending != .null) {
+                try self.space();
+                try self.writeStr("@pending ");
+                try self.emit(t.pending);
+            }
+
+            if (statement.handler != .null) {
+                try self.space();
+                try self.emitTsrxCatchClause(statement.handler);
+            }
+        }
+
+        fn emitTsrxCatchClause(self: *Self, idx: NodeIndex) Error!void {
+            const catch_clause = self.nodeData(idx).catch_clause;
+
+            try self.writeStr("@catch");
+            if (catch_clause.param != .null) {
+                try self.space();
+                try self.writeByte('(');
+                try self.emit(catch_clause.param);
+                if (catch_clause.reset_param != .null) {
+                    try self.writeStr(", ");
+                    try self.emit(catch_clause.reset_param);
+                }
+                try self.writeByte(')');
+            }
+            try self.space();
+            try self.emit(catch_clause.body);
         }
     };
 }

--- a/src/parser/ffi/parser.d.ts
+++ b/src/parser/ffi/parser.d.ts
@@ -110,6 +110,7 @@ export function walk<T extends Node, S = unknown>(root: T, visitors: Visitors<S>
  * Resolves a {@link SourceLang} from a file path's extension.
  *
  * - `.d.ts`, `.d.mts`, `.d.cts` → `"dts"`
+ * - `.tsrx` → `"tsrx"`
  * - `.tsx` → `"tsx"`
  * - `.ts`, `.mts`, `.cts` → `"ts"`
  * - `.jsx` → `"jsx"`

--- a/src/parser/ffi/wasm/parser.zig
+++ b/src/parser/ffi/wasm/parser.zig
@@ -11,6 +11,15 @@ const std = @import("std");
 const parser = @import("parser");
 const transfer = @import("transfer");
 
+comptime {
+    std.debug.assert(@intFromEnum(parser.ast.Lang.js) == 0);
+    std.debug.assert(@intFromEnum(parser.ast.Lang.ts) == 1);
+    std.debug.assert(@intFromEnum(parser.ast.Lang.jsx) == 2);
+    std.debug.assert(@intFromEnum(parser.ast.Lang.tsx) == 3);
+    std.debug.assert(@intFromEnum(parser.ast.Lang.dts) == 4);
+    std.debug.assert(@intFromEnum(parser.ast.Lang.tsrx) == 5);
+}
+
 const gpa = std.heap.wasm_allocator;
 
 // Option bits packed by index.js `packFlags`.

--- a/src/parser/fuzz/core.zig
+++ b/src/parser/fuzz/core.zig
@@ -15,6 +15,7 @@ pub const modes = [_]Mode{
     .{ .lang = .tsx, .source_type = .module },
     .{ .lang = .jsx, .source_type = .module },
     .{ .lang = .dts, .source_type = .module },
+    .{ .lang = .tsrx, .source_type = .module },
 };
 
 // adversarial fragments: surrogate and overlong escapes, unterminated literals,

--- a/src/parser/lexer.zig
+++ b/src/parser/lexer.zig
@@ -447,9 +447,9 @@ pub const Lexer = struct {
         return self.createToken(.less_than, token_start, token_start + 1);
     }
 
-    /// scans JSX text content between '<' and '{' in JSX children.
+    /// scans JSX text content between '<', '{', and TSRX directives in JSX children.
     /// called by the parser when parsing JSX element children.
-    pub fn reScanJsxText(self: *Lexer, initial_cursor: u32) Token {
+    pub fn reScanJsxText(self: *Lexer, initial_cursor: u32, stop_at_tsrx_code: bool) Token {
         std.debug.assert(initial_cursor <= self.source.len);
         self.rewindTo(initial_cursor);
 
@@ -460,12 +460,45 @@ pub const Lexer = struct {
 
             switch (c) {
                 '<', '{' => break,
+                '@' => {
+                    if (stop_at_tsrx_code and self.isTsrxTemplateAtSign()) break;
+                    self.cursor += 1;
+                },
                 else => self.cursor += 1,
             }
         }
 
         std.debug.assert(self.cursor >= start);
         return self.createToken(.jsx_text, start, self.cursor);
+    }
+
+    fn isTsrxTemplateAtSign(self: *const Lexer) bool {
+        std.debug.assert(self.cursor < self.source.len);
+        std.debug.assert(self.source[self.cursor] == '@');
+
+        if (self.peek(1) == '{') return true;
+
+        const start = self.cursor + 1;
+        return self.matchesTsrxDirective(start, "if") or
+            self.matchesTsrxDirective(start, "for") or
+            self.matchesTsrxDirective(start, "switch") or
+            self.matchesTsrxDirective(start, "try");
+    }
+
+    fn matchesTsrxDirective(self: *const Lexer, start: u32, word: []const u8) bool {
+        std.debug.assert(start <= self.source.len);
+        std.debug.assert(word.len > 0);
+
+        const end = start + @as(u32, @intCast(word.len));
+        if (end > self.source.len) return false;
+        if (!std.mem.eql(u8, self.source[start..end], word)) return false;
+        if (end == self.source.len) return true;
+
+        return !isAsciiIdentifierContinue(self.source[end]);
+    }
+
+    fn isAsciiIdentifierContinue(c: u8) bool {
+        return std.ascii.isAlphanumeric(c) or c == '_' or c == '$';
     }
 
     const RegexResult = struct {

--- a/src/parser/semantic/scope.zig
+++ b/src/parser/semantic/scope.zig
@@ -56,11 +56,19 @@ pub const Scope = struct {
         /// TS namespace body. Acts as a var-hoist target so vars
         /// declared inside don't escape to the surrounding scope.
         ts_module,
+        /// TSRX code block scope for `@{ ... }`.
+        tsrx_code_block,
 
         /// Returns whether `var` declarations hoist to this scope kind.
         pub fn isHoistTarget(kind: Kind) bool {
             return switch (kind) {
-                .global, .module, .function, .static_block, .ts_module => true,
+                .global,
+                .module,
+                .function,
+                .static_block,
+                .ts_module,
+                .tsrx_code_block,
+                => true,
                 else => false,
             };
         }
@@ -253,6 +261,7 @@ pub const ScopeTracker = struct {
             .ts_conditional_type,
             => try self.pushScope(.block, index, self.inheritStrictFlag()),
             .ts_module_block => try self.pushScope(.ts_module, index, self.inheritStrictFlag()),
+            .jsx_code_block => try self.pushScope(.tsrx_code_block, index, self.inheritStrictFlag()),
             .class => |cls| {
                 // section 15.7.14: classes are always strict mode.
                 const flags = Scope.Flags{ .strict = true };
@@ -351,6 +360,7 @@ pub const ScopeTracker = struct {
             .ts_index_signature,
             .ts_mapped_type,
             .ts_conditional_type,
+            .jsx_code_block,
             => self.popScope(),
             .block_statement => {
                 // catch body blocks share the catch scope (Section 14.15.2)

--- a/src/parser/syntax/expressions.zig
+++ b/src/parser/syntax/expressions.zig
@@ -24,6 +24,8 @@ const patterns = @import("patterns.zig");
 const modules = @import("modules.zig");
 const grammar = @import("../grammar.zig");
 const ts = @import("ts/types.zig");
+const tsrx = @import("tsrx/root.zig");
+const tsrx_template = @import("tsrx/template.zig");
 
 const ParseExpressionOpts = struct {
     /// whether we are parsing this expression in a cover context.
@@ -117,9 +119,23 @@ fn parsePrefix(parser: *Parser, opts: ParseExpressionOpts, precedence: u8) Error
     }
 
     if (tag == .at) {
+        if (tsrx.isCodeBlockStart(parser)) return tsrx_template.parseCodeBlock(parser);
+        if (tsrx.isControlFlowDirectiveStart(parser)) return tsrx_template.parseControlFlowExpression(parser);
+
         const start = parser.current_token.span.start;
         const decorators = try extensions.parseDecorators(parser) orelse return null;
         return class.parseClassDecorated(parser, .{ .is_expression = true }, start, decorators);
+    }
+
+    if (tag == .bitwise_and and patterns.isLazyPatternStart(parser)) {
+        if (parser.tree.isTsrx()) return parseLazyAssignmentPattern(parser);
+
+        try parser.report(
+            parser.current_token.span,
+            "Lazy destructuring assignments are only enabled in TSRX files",
+            .{ .help = "Use a .tsrx file or remove the '&' lazy-pattern marker." },
+        );
+        return null;
     }
 
     if (tag.isUnaryOperator()) {
@@ -162,6 +178,33 @@ fn parsePrefix(parser: *Parser, opts: ParseExpressionOpts, precedence: u8) Error
     }
 
     return parsePrimaryExpression(parser, opts);
+}
+
+fn parseLazyAssignmentPattern(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(parser.current_token.tag == .bitwise_and);
+    std.debug.assert(patterns.isLazyPatternStart(parser));
+
+    const ampersand = parser.current_token;
+    try parser.advance() orelse return null;
+
+    const left = switch (parser.current_token.tag) {
+        .left_bracket => try parseArrayExpression(parser, true) orelse return null,
+        .left_brace => try parseObjectExpression(parser, true) orelse return null,
+        else => unreachable,
+    };
+
+    try grammar.expressionToPattern(parser, left, .assignable);
+    patterns.markLazyPattern(parser, left, ampersand.span.start);
+
+    if (parser.current_token.tag != .assign) {
+        try parser.reportExpected(
+            parser.current_token.span,
+            "Expected '=' after lazy destructuring assignment pattern",
+            .{ .help = "Lazy destructuring at statement level must assign from a value." },
+        );
+    }
+
+    return left;
 }
 
 fn parseInfix(parser: *Parser, precedence: u8, left: ast.NodeIndex) Error!?ast.NodeIndex {

--- a/src/parser/syntax/for_loop.zig
+++ b/src/parser/syntax/for_loop.zig
@@ -10,9 +10,19 @@ const variables = @import("variables.zig");
 const grammar = @import("../grammar.zig");
 const statements = @import("statements.zig");
 
+const BodyParser = fn (*Parser) Error!?ast.NodeIndex;
+
 /// https://tc39.es/ecma262/#sec-for-statement
 /// https://tc39.es/ecma262/#sec-for-in-and-for-of-statements
 pub fn parseForStatement(parser: *Parser, is_for_await: bool) Error!?ast.NodeIndex {
+    return parseForStatementWithBody(parser, is_for_await, parseNormalForBody);
+}
+
+pub fn parseForStatementWithBody(
+    parser: *Parser,
+    is_for_await: bool,
+    comptime parse_body: BodyParser,
+) Error!?ast.NodeIndex {
     std.debug.assert(parser.current_token.tag == .@"for");
     const start = parser.current_token.span.start;
     try parser.advance() orelse return null; // consume 'for'
@@ -30,16 +40,21 @@ pub fn parseForStatement(parser: *Parser, is_for_await: bool) Error!?ast.NodeInd
 
         if (!try parser.expect(.left_paren, "Expected '(' after 'for await'", null)) return null;
 
-        return parseForHead(parser, start, true);
+        return parseForHead(parser, start, true, parse_body);
     }
 
     if (!try parser.expect(.left_paren, "Expected '(' after 'for'", null)) return null;
-    return parseForHead(parser, start, is_for_await);
+    return parseForHead(parser, start, is_for_await, parse_body);
 }
 
-fn parseForHead(parser: *Parser, start: u32, is_for_await: bool) Error!?ast.NodeIndex {
+fn parseForHead(
+    parser: *Parser,
+    start: u32,
+    is_for_await: bool,
+    comptime parse_body: BodyParser,
+) Error!?ast.NodeIndex {
     if (parser.current_token.tag == .semicolon) {
-        return parseForStatementRest(parser, start, .null, is_for_await);
+        return parseForStatementRest(parser, start, .null, is_for_await, parse_body);
     }
 
     const decl_start = parser.current_token.span.start;
@@ -55,14 +70,21 @@ fn parseForHead(parser: *Parser, start: u32, is_for_await: bool) Error!?ast.Node
 
             try parser.advance() orelse return null;
 
-            return parseForWithDeclaration(parser, start, is_for_await, kind, decl_start);
+            return parseForWithDeclaration(
+                parser,
+                start,
+                is_for_await,
+                kind,
+                decl_start,
+                parse_body,
+            );
         },
         .using => {
             const next = parser.peekAhead() orelse return null;
 
             // [+Using] using [no LineTerminator here] ForBinding
             if (next.hasLineTerminatorBefore()) {
-                return parseForWithExpression(parser, start, is_for_await);
+                return parseForWithExpression(parser, start, is_for_await, parse_body);
             }
 
             switch (next.tag) {
@@ -72,7 +94,7 @@ fn parseForHead(parser: *Parser, start: u32, is_for_await: bool) Error!?ast.Node
                 // by returning null (not a declaration), the caller produces a natural
                 // "expected ';', found '{'" error.
                 .in, .dot, .left_paren, .left_bracket, .left_brace => {
-                    return parseForWithExpression(parser, start, is_for_await);
+                    return parseForWithExpression(parser, start, is_for_await, parse_body);
                 },
                 // `using of` is ambiguous because `of` is a valid identifier:
                 //   `for (using of expr)` -> for-of loop, `using` is the expression
@@ -92,15 +114,29 @@ fn parseForHead(parser: *Parser, start: u32, is_for_await: bool) Error!?ast.Node
                         is_for_await,
                         .using,
                         decl_start,
+                        parse_body,
                     );
 
                     try grammar.expressionToPattern(parser, using_identifier, .assignable);
 
-                    return parseForOfStatementRest(parser, start, using_identifier, is_for_await);
+                    return parseForOfStatementRest(
+                        parser,
+                        start,
+                        using_identifier,
+                        is_for_await,
+                        parse_body,
+                    );
                 },
                 else => {
                     try parser.advance() orelse return null;
-                    return parseForWithDeclaration(parser, start, is_for_await, .using, decl_start);
+                    return parseForWithDeclaration(
+                        parser,
+                        start,
+                        is_for_await,
+                        .using,
+                        decl_start,
+                        parse_body,
+                    );
                 },
             }
         },
@@ -108,15 +144,22 @@ fn parseForHead(parser: *Parser, start: u32, is_for_await: bool) Error!?ast.Node
             const next = parser.peekAhead() orelse return null;
 
             if (next.tag != .using or next.hasLineTerminatorBefore()) {
-                return parseForWithExpression(parser, start, is_for_await);
+                return parseForWithExpression(parser, start, is_for_await, parse_body);
             }
 
             try parser.advance() orelse return null; // consume 'await'
             try parser.advance() orelse return null; // consume 'using'
 
-            return parseForWithDeclaration(parser, start, is_for_await, .await_using, decl_start);
+            return parseForWithDeclaration(
+                parser,
+                start,
+                is_for_await,
+                .await_using,
+                decl_start,
+                parse_body,
+            );
         },
-        else => return parseForWithExpression(parser, start, is_for_await),
+        else => return parseForWithExpression(parser, start, is_for_await, parse_body),
     }
 }
 
@@ -127,6 +170,7 @@ fn parseForWithDeclaration(
     is_for_await: bool,
     kind: ast.VariableKind,
     decl_start: u32,
+    comptime parse_body: BodyParser,
 ) Error!?ast.NodeIndex {
     const saved_allow_in = parser.context.in;
     parser.context.in = false;
@@ -173,20 +217,25 @@ fn parseForWithDeclaration(
                 .{ .help = "Did you mean to use a for...of statement?" },
             );
         }
-        return parseForInStatementRest(parser, start, decl, is_for_await);
+        return parseForInStatementRest(parser, start, decl, is_for_await, parse_body);
     }
 
     if (parser.current_token.tag == .of) {
-        return parseForOfStatementRest(parser, start, decl, is_for_await);
+        return parseForOfStatementRest(parser, start, decl, is_for_await, parse_body);
     }
 
     if (!try validateRegularForDeclarators(parser, declarators, kind)) return null;
 
-    return parseForStatementRest(parser, start, decl, is_for_await);
+    return parseForStatementRest(parser, start, decl, is_for_await, parse_body);
 }
 
 /// for loop starting with an expression.
-fn parseForWithExpression(parser: *Parser, start: u32, is_for_await: bool) Error!?ast.NodeIndex {
+fn parseForWithExpression(
+    parser: *Parser,
+    start: u32,
+    is_for_await: bool,
+    comptime parse_body: BodyParser,
+) Error!?ast.NodeIndex {
     const saved_allow_in = parser.context.in;
     parser.context.in = false;
 
@@ -204,7 +253,7 @@ fn parseForWithExpression(parser: *Parser, start: u32, is_for_await: bool) Error
     if (parser.current_token.tag == .in) {
         try grammar.expressionToPattern(parser, expr, .assignable);
 
-        return parseForInStatementRest(parser, start, expr, is_for_await);
+        return parseForInStatementRest(parser, start, expr, is_for_await, parse_body);
     }
 
     if (parser.current_token.tag == .of) {
@@ -220,10 +269,10 @@ fn parseForWithExpression(parser: *Parser, start: u32, is_for_await: bool) Error
 
         try grammar.expressionToPattern(parser, expr, .assignable);
 
-        return parseForOfStatementRest(parser, start, expr, is_for_await);
+        return parseForOfStatementRest(parser, start, expr, is_for_await, parse_body);
     }
 
-    return parseForStatementRest(parser, start, expr, is_for_await);
+    return parseForStatementRest(parser, start, expr, is_for_await, parse_body);
 }
 
 /// for(init; test; update) body
@@ -232,6 +281,7 @@ fn parseForStatementRest(
     start: u32,
     init: ast.NodeIndex,
     is_for_await: bool,
+    comptime parse_body: BodyParser,
 ) Error!?ast.NodeIndex {
     if (is_for_await) {
         try parser.report(
@@ -264,10 +314,7 @@ fn parseForStatementRest(
         return null;
     }
 
-    const body = try statements.parseStatement(
-        parser,
-        .{ .can_be_single_statement_context = true },
-    ) orelse return null;
+    const body = try parse_body(parser) orelse return null;
 
     return try parser.tree.addNode(.{
         .for_statement = .{
@@ -285,6 +332,7 @@ fn parseForInStatementRest(
     start: u32,
     left: ast.NodeIndex,
     is_for_await: bool,
+    comptime parse_body: BodyParser,
 ) Error!?ast.NodeIndex {
     if (is_for_await) {
         try parser.report(
@@ -302,10 +350,7 @@ fn parseForInStatementRest(
         return null;
     }
 
-    const body = try statements.parseStatement(
-        parser,
-        .{ .can_be_single_statement_context = true },
-    ) orelse return null;
+    const body = try parse_body(parser) orelse return null;
 
     return try parser.tree.addNode(.{
         .for_in_statement = .{
@@ -322,20 +367,48 @@ fn parseForOfStatementRest(
     start: u32,
     left: ast.NodeIndex,
     is_for_await: bool,
+    comptime parse_body: BodyParser,
 ) Error!?ast.NodeIndex {
     try parser.advance() orelse return null; // consume 'of'
 
     const right = try expressions.parseExpression(parser, Precedence.Assignment, .{}) orelse
         return null;
 
+    var index: ast.NodeIndex = .null;
+    var key: ast.NodeIndex = .null;
+    if (parser.tree.isTsrx() and parser.current_token.tag == .semicolon) {
+        try parser.advance() orelse return null; // consume ';'
+
+        if (isContextualIdentifier(parser, "index")) {
+            try parser.advance() orelse return null; // consume 'index'
+            index = try literals.parseIdentifier(parser) orelse return null;
+
+            if (parser.current_token.tag == .semicolon) {
+                try parser.advance() orelse return null; // consume ';'
+            }
+        }
+
+        if (isContextualIdentifier(parser, "key")) {
+            try parser.advance() orelse return null; // consume 'key'
+            key = try expressions.parseExpression(parser, Precedence.Assignment, .{}) orelse
+                return null;
+        }
+
+        if (isContextualIdentifier(parser, "index")) {
+            try parser.report(
+                parser.current_token.span,
+                "'index' must come before 'key' in a TSRX for-of header",
+                .{},
+            );
+            return null;
+        }
+    }
+
     if (!try parser.expect(.right_paren, "Expected ')' after for-of expression", null)) {
         return null;
     }
 
-    const body = try statements.parseStatement(
-        parser,
-        .{ .can_be_single_statement_context = true },
-    ) orelse return null;
+    const body = try parse_body(parser) orelse return null;
 
     return try parser.tree.addNode(.{
         .for_of_statement = .{
@@ -343,8 +416,17 @@ fn parseForOfStatementRest(
             .right = right,
             .body = body,
             .await = is_for_await,
+            .index = index,
+            .key = key,
         },
     }, .{ .start = start, .end = parser.tree.span(body).end });
+}
+
+fn parseNormalForBody(parser: *Parser) Error!?ast.NodeIndex {
+    return statements.parseStatement(
+        parser,
+        .{ .can_be_single_statement_context = true },
+    );
 }
 
 fn isAsyncIdentifier(parser: *Parser, expr: ast.NodeIndex) bool {
@@ -353,6 +435,13 @@ fn isAsyncIdentifier(parser: *Parser, expr: ast.NodeIndex) bool {
     // compare raw source text, escaped `\u0061sync` should not match
     const span = parser.tree.span(expr);
     return std.mem.eql(u8, parser.source[span.start..span.end], "async");
+}
+
+fn isContextualIdentifier(parser: *const Parser, expected: []const u8) bool {
+    if (parser.current_token.tag != .identifier) return false;
+
+    const span = parser.current_token.span;
+    return std.mem.eql(u8, parser.source[span.start..span.end], expected);
 }
 
 fn validateRegularForDeclarators(

--- a/src/parser/syntax/functions.zig
+++ b/src/parser/syntax/functions.zig
@@ -8,6 +8,8 @@ const literals = @import("literals.zig");
 const patterns = @import("patterns.zig");
 const extensions = @import("extensions.zig");
 const ts = @import("ts/types.zig");
+const tsrx = @import("tsrx/root.zig");
+const tsrx_template = @import("tsrx/template.zig");
 
 const ParseFunctionOpts = struct {
     is_async: bool = false,
@@ -119,7 +121,8 @@ pub fn parseFunction(
 
     // function expressions always carry a body, only declarations obey ambient rules.
     const is_ambient_declaration = parser.ts_context.ambient and !is_function_expression;
-    if (is_ambient_declaration and parser.current_token.tag == .left_brace) {
+    const has_tsrx_body = tsrx.isCodeBlockStart(parser);
+    if (is_ambient_declaration and (parser.current_token.tag == .left_brace or has_tsrx_body)) {
         try parser.report(
             parser.current_token.span,
             "An implementation cannot be declared in ambient contexts",
@@ -130,7 +133,8 @@ pub fn parseFunction(
 
     // ts ambient declarations and overload signatures are body-less.
     const has_body = !is_ambient_declaration and
-        (!is_ts or is_function_expression or parser.current_token.tag == .left_brace);
+        (!is_ts or is_function_expression or parser.current_token.tag == .left_brace or
+            has_tsrx_body);
     const body: ast.NodeIndex = if (has_body)
         try parseFunctionBody(parser) orelse .null
     else
@@ -187,6 +191,14 @@ pub fn parseFunction(
 }
 
 pub fn parseFunctionBody(parser: *Parser) Error!?ast.NodeIndex {
+    const saved_allow_return_statement = parser.context.@"return";
+    parser.context.@"return" = true;
+    defer {
+        parser.context.@"return" = saved_allow_return_statement;
+    }
+
+    if (tsrx.isCodeBlockStart(parser)) return tsrx_template.parseCodeBlock(parser);
+
     const start = parser.current_token.span.start;
 
     if (!try parser.expect(
@@ -194,14 +206,6 @@ pub fn parseFunctionBody(parser: *Parser) Error!?ast.NodeIndex {
         "Expected '{' to start function body",
         "Function bodies must be enclosed in braces: function name() { ... }",
     )) return null;
-
-    const saved_allow_return_statement = parser.context.@"return";
-
-    parser.context.@"return" = true;
-
-    defer {
-        parser.context.@"return" = saved_allow_return_statement;
-    }
 
     const body = try parser.parseBody(.right_brace, .function);
 

--- a/src/parser/syntax/jsx/root.zig
+++ b/src/parser/syntax/jsx/root.zig
@@ -1,12 +1,16 @@
 const std = @import("std");
 const ast = @import("../../ast.zig");
 const Precedence = @import("../../token.zig").Precedence;
+const Token = @import("../../token.zig").Token;
 const Parser = @import("../../parser.zig").Parser;
 const Error = @import("../../parser.zig").Error;
 
 const literals = @import("../literals.zig");
 const expressions = @import("../expressions.zig");
 const ts = @import("../ts/types.zig");
+const tsrx = @import("../tsrx/root.zig");
+const tsrx_dynamic_tag = @import("../tsrx/dynamic_tag.zig");
+const tsrx_template = @import("../tsrx/template.zig");
 
 /// context for JSX element parsing, determines post-parse behavior
 const JsxElementContext = enum {
@@ -45,6 +49,17 @@ fn parseJsxElement(parser: *Parser, comptime context: JsxElementContext) Error!?
     const opening_data = parser.tree.data(opening).jsx_opening_element;
     const opening_end = parser.tree.span(opening).end;
 
+    if (isTsrxStyleElementName(parser, opening_data.name)) {
+        return try parseTsrxStyleElement(
+            parser,
+            opening,
+            opening_data,
+            start,
+            opening_end,
+            context,
+        );
+    }
+
     // self-closing element: <elem />
     if (opening_data.self_closing) {
         return try parser.tree.addNode(.{
@@ -72,6 +87,101 @@ fn parseJsxElement(parser: *Parser, comptime context: JsxElementContext) Error!?
             .closing_element = closing,
         },
     }, .{ .start = start, .end = parser.tree.span(closing).end });
+}
+
+fn parseTsrxStyleElement(
+    parser: *Parser,
+    opening: ast.NodeIndex,
+    opening_data: ast.JSXOpeningElement,
+    start: u32,
+    opening_end: u32,
+    comptime context: JsxElementContext,
+) Error!?ast.NodeIndex {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(isTsrxStyleElementName(parser, opening_data.name));
+    std.debug.assert(start <= opening_end);
+
+    if (opening_data.self_closing) {
+        return try parser.tree.addNode(.{
+            .jsx_style_element = .{
+                .opening_element = opening,
+                .children = ast.IndexRange.empty,
+                .closing_element = .null,
+                .css = .empty,
+            },
+        }, .{ .start = start, .end = opening_end });
+    }
+
+    const close_text = "</style>";
+    const close_index = std.mem.indexOfPos(u8, parser.source, opening_end, close_text) orelse {
+        try parser.report(
+            .{ .start = opening_end, .end = opening_end },
+            "Unclosed TSRX style element",
+            .{ .help = "Add '</style>' before the end of the template." },
+        );
+        return null;
+    };
+
+    const close_start: u32 = @intCast(close_index);
+    const close_end = close_start + @as(u32, @intCast(close_text.len));
+
+    const css = parser.tree.sourceSlice(opening_end, close_start);
+    const style_sheet = try parser.tree.addNode(
+        .{ .style_sheet = .{ .source = css } },
+        .{ .start = opening_end, .end = close_start },
+    );
+    const children = try parser.tree.addExtra(&.{style_sheet});
+
+    const name_start = close_start + 2;
+    const name_end = name_start + @as(u32, @intCast("style".len));
+    const name = try parser.tree.addNode(.{
+        .jsx_identifier = .{ .name = parser.tree.sourceSlice(name_start, name_end) },
+    }, .{ .start = name_start, .end = name_end });
+    const closing = try parser.tree.addNode(
+        .{ .jsx_closing_element = .{ .name = name } },
+        .{ .start = close_start, .end = close_end },
+    );
+
+    try finishTsrxStyleElement(parser, close_end, context) orelse return null;
+
+    return try parser.tree.addNode(.{
+        .jsx_style_element = .{
+            .opening_element = opening,
+            .children = children,
+            .closing_element = closing,
+            .css = css,
+        },
+    }, .{ .start = start, .end = close_end });
+}
+
+fn finishTsrxStyleElement(
+    parser: *Parser,
+    close_end: u32,
+    comptime context: JsxElementContext,
+) Error!?void {
+    std.debug.assert(close_end <= parser.source.len);
+
+    const closing_gt: Token = .{
+        .tag = .greater_than,
+        .span = .{ .start = close_end - 1, .end = close_end },
+    };
+
+    parser.lexer.rewindTo(close_end);
+    switch (context) {
+        .child => {
+            exitJsxTag(parser);
+            parser.current_token = closing_gt;
+            parser.prev_token_end = close_end;
+        },
+        .top_level => {
+            exitJsxTag(parser);
+            try parser.advanceWithRescannedToken(closing_gt) orelse return null;
+        },
+        .attribute => {
+            enterJsxTag(parser);
+            try parser.advanceWithRescannedToken(closing_gt) orelse return null;
+        },
+    }
 }
 
 // https://facebook.github.io/jsx/#prod-JSXFragment
@@ -273,6 +383,20 @@ fn parseJsxClosingElement(
 }
 
 fn jsxNamesMatch(parser: *const Parser, a: ast.NodeIndex, b: ast.NodeIndex) bool {
+    switch (parser.tree.data(a)) {
+        .jsx_expression_container => |a_container| switch (parser.tree.data(b)) {
+            .jsx_expression_container => |b_container| {
+                const expression_a = parser.spanText(parser.tree.span(a_container.expression));
+                const expression_b = parser.spanText(parser.tree.span(b_container.expression));
+                const trimmed_a = std.mem.trim(u8, expression_a, " \t\r\n");
+                const trimmed_b = std.mem.trim(u8, expression_b, " \t\r\n");
+                return std.mem.eql(u8, trimmed_a, trimmed_b);
+            },
+            else => {},
+        },
+        else => {},
+    }
+
     const span_a = parser.tree.span(a);
     const span_b = parser.tree.span(b);
 
@@ -287,6 +411,15 @@ fn jsxNamesMatch(parser: *const Parser, a: ast.NodeIndex, b: ast.NodeIndex) bool
     return std.mem.eql(u8, text_a, text_b);
 }
 
+fn isTsrxStyleElementName(parser: *const Parser, name: ast.NodeIndex) bool {
+    if (!parser.tree.isTsrx()) return false;
+
+    return switch (parser.tree.data(name)) {
+        .jsx_identifier => |id| std.mem.eql(u8, parser.tree.string(id.name), "style"),
+        else => false,
+    };
+}
+
 // https://facebook.github.io/jsx/#prod-JSXChildren
 fn parseJsxChildren(parser: *Parser, gt_end: u32) Error!?ast.IndexRange {
     const checkpoint = parser.scratch_b.begin();
@@ -299,12 +432,12 @@ fn parseJsxChildren(parser: *Parser, gt_end: u32) Error!?ast.IndexRange {
 
     while (true) {
         // scan text content until '<' or '{'
-        const text_token = parser.lexer.reScanJsxText(scan_from);
+        const text_token = parser.lexer.reScanJsxText(scan_from, parser.tree.isTsrx());
 
         if (text_token.len() > 0) {
             const text_node = try parser.tree.addNode(.{
                 .jsx_text = .{
-                    .value = parser.tree.sourceSlice(text_token.span.start, text_token.span.end),
+                    .value = try parseJsxTextValue(parser, text_token.span),
                 },
             }, text_token.span);
 
@@ -330,11 +463,136 @@ fn parseJsxChildren(parser: *Parser, gt_end: u32) Error!?ast.IndexRange {
                 scan_from = parser.tree.span(child).end;
                 try parser.scratch_b.append(parser.allocator(), child);
             },
+            .at => {
+                const child = if (tsrx.isCodeBlockStart(parser))
+                    try tsrx_template.parseCodeBlock(parser) orelse return null
+                else if (tsrx.isControlFlowDirectiveStart(parser))
+                    try tsrx_template.parseControlFlowExpression(parser) orelse return null
+                else {
+                    try parser.reportExpected(
+                        parser.current_token.span,
+                        "Expected TSRX template directive",
+                        .{ .help = "TSRX template directives are '@{...}', '@if', '@for'," ++
+                            " '@switch', or '@try'." },
+                    );
+                    return null;
+                };
+                scan_from = parser.tree.span(child).end;
+                try parser.scratch_b.append(parser.allocator(), child);
+            },
             else => break,
         }
     }
 
     return try parser.flushToExtras(&parser.scratch_b, checkpoint);
+}
+
+fn parseJsxTextValue(parser: *Parser, span: ast.Span) Error!ast.String {
+    std.debug.assert(span.start <= span.end);
+    std.debug.assert(span.end <= parser.source.len);
+
+    const text = parser.spanText(span);
+    if (std.mem.indexOfScalar(u8, text, '&') == null) {
+        return parser.tree.sourceSlice(span.start, span.end);
+    }
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(parser.allocator());
+    try out.ensureTotalCapacity(parser.allocator(), text.len);
+
+    var index: u32 = 0;
+    while (index < text.len) {
+        if (text[index] != '&') {
+            try out.append(parser.allocator(), text[index]);
+            index += 1;
+            continue;
+        }
+
+        const entity = parseJsxTextEntity(text[index..]) orelse {
+            try out.append(parser.allocator(), text[index]);
+            index += 1;
+            continue;
+        };
+
+        if (entity.codepoint) |codepoint| {
+            var bytes: [4]u8 = undefined;
+            const len = std.unicode.utf8Encode(codepoint, &bytes) catch unreachable;
+            try out.appendSlice(parser.allocator(), bytes[0..len]);
+        } else {
+            try out.appendSlice(parser.allocator(), entity.value);
+        }
+        index += entity.len;
+    }
+
+    return try parser.tree.addString(out.items);
+}
+
+const JsxTextEntity = struct {
+    value: []const u8 = "",
+    codepoint: ?u21 = null,
+    len: u32,
+};
+
+fn parseJsxTextEntity(text: []const u8) ?JsxTextEntity {
+    std.debug.assert(text.len > 0);
+    std.debug.assert(text[0] == '&');
+
+    if (text.len < 4) return null;
+
+    if (std.mem.startsWith(u8, text, "&amp;")) {
+        return .{ .value = "&", .len = 5 };
+    }
+    if (std.mem.startsWith(u8, text, "&lt;")) {
+        return .{ .value = "<", .len = 4 };
+    }
+    if (std.mem.startsWith(u8, text, "&gt;")) {
+        return .{ .value = ">", .len = 4 };
+    }
+    if (std.mem.startsWith(u8, text, "&quot;")) {
+        return .{ .value = "\"", .len = 6 };
+    }
+    if (std.mem.startsWith(u8, text, "&apos;")) {
+        return .{ .value = "'", .len = 6 };
+    }
+    if (std.mem.startsWith(u8, text, "&nbsp;")) {
+        return .{ .value = "\u{00a0}", .len = 6 };
+    }
+    if (text[1] == '#') {
+        return parseJsxNumericTextEntity(text);
+    }
+
+    return null;
+}
+
+fn parseJsxNumericTextEntity(text: []const u8) ?JsxTextEntity {
+    std.debug.assert(text.len >= 2);
+    std.debug.assert(text[0] == '&');
+    std.debug.assert(text[1] == '#');
+
+    var base: u8 = 10;
+    var index: u32 = 2;
+    if (index < text.len and (text[index] == 'x' or text[index] == 'X')) {
+        base = 16;
+        index += 1;
+    }
+
+    const digits_start = index;
+    var codepoint: u32 = 0;
+    while (index < text.len) : (index += 1) {
+        const c = text[index];
+        if (c == ';') break;
+        const digit = std.fmt.charToDigit(c, base) catch return null;
+        if (codepoint > (@as(u32, 0x10ffff) - digit) / base) return null;
+        codepoint = codepoint * base + digit;
+    }
+
+    if (index == text.len) return null;
+    if (text[index] != ';') return null;
+    if (index == digits_start) return null;
+    if (codepoint > 0x10ffff) return null;
+    if (codepoint >= 0xd800 and codepoint <= 0xdfff) return null;
+
+    return .{ .codepoint = @intCast(codepoint), .len = index + 1 };
 }
 
 fn parseJsxChildFromLeftBrace(parser: *Parser) Error!?ast.NodeIndex {
@@ -612,6 +870,21 @@ fn parseJsxSpreadAttribute(parser: *Parser) Error!?ast.NodeIndex {
 
 // https://facebook.github.io/jsx/#prod-JSXElementName
 fn parseJsxElementName(parser: *Parser) Error!?ast.NodeIndex {
+    if (parser.current_token.tag == .left_brace) {
+        if (parser.tree.isTsrx()) {
+            const name = try parseJsxExpressionContainer(parser, .tag) orelse return null;
+            try tsrx_dynamic_tag.validateExpression(parser, name);
+            return name;
+        }
+
+        try parser.reportExpected(
+            parser.current_token.span,
+            "Expected JSX element name",
+            .{ .help = "Dynamic JSX tag names are only enabled in TSRX files" },
+        );
+        return null;
+    }
+
     if (parser.current_token.tag != .jsx_identifier) {
         try parser.reportExpected(
             parser.current_token.span,

--- a/src/parser/syntax/modules.zig
+++ b/src/parser/syntax/modules.zig
@@ -917,16 +917,27 @@ fn parseModuleExportName(parser: *Parser) Error!?ast.NodeIndex {
     return null;
 }
 
-// module string
+// module string or TSRX submodule identifier
 fn parseModuleSpecifier(parser: *Parser) Error!?ast.NodeIndex {
-    if (parser.current_token.tag != .string_literal) {
-        try parser.reportExpected(parser.current_token.span, "Expected module specifier", .{
-            .help = "Module specifiers must be string literals, e.g., './module.js' or 'package'",
+    if (parser.current_token.tag == .string_literal) {
+        return literals.parseStringLiteral(parser);
+    }
+
+    if (parser.tree.isTsrx() and parser.current_token.tag.isIdentifierLike()) {
+        return literals.parseIdentifier(parser);
+    }
+
+    if (parser.current_token.tag.isIdentifierLike()) {
+        try parser.report(parser.current_token.span, "Identifier module specifiers require TSRX", .{
+            .help = "Use a .tsrx file for submodule imports such as import { load } from server.",
         });
         return null;
     }
 
-    return literals.parseStringLiteral(parser);
+    try parser.reportExpected(parser.current_token.span, "Expected module specifier", .{
+        .help = "Module specifiers must be string literals, e.g., './module.js' or 'package'",
+    });
+    return null;
 }
 
 // import attributes with { } or legacy assert { }

--- a/src/parser/syntax/patterns.zig
+++ b/src/parser/syntax/patterns.zig
@@ -16,6 +16,7 @@ pub inline fn parseBindingPattern(parser: *Parser) Error!?ast.NodeIndex {
     }
 
     return switch (parser.current_token.tag) {
+        .bitwise_and => parseLazyBindingPattern(parser),
         .left_bracket => parseArrayPattern(parser),
         .left_brace => parseObjectPattern(parser),
         else => {
@@ -31,6 +32,81 @@ pub inline fn parseBindingPattern(parser: *Parser) Error!?ast.NodeIndex {
             return null;
         },
     };
+}
+
+pub fn isLazyPatternStart(parser: *Parser) bool {
+    if (parser.current_token.tag != .bitwise_and) return false;
+
+    const ampersand = parser.current_token;
+    var peek = parser.beginPeek();
+    defer peek.end();
+
+    const next = peek.next() orelse return false;
+    if (ampersand.span.end != next.span.start) return false;
+
+    return next.tag == .left_brace or next.tag == .left_bracket;
+}
+
+pub fn markLazyPattern(parser: *Parser, pattern: ast.NodeIndex, start: u32) void {
+    const span = parser.tree.span(pattern);
+    std.debug.assert(start <= span.start);
+
+    switch (parser.tree.data(pattern)) {
+        .array_pattern => |array_pattern| {
+            var lazy_pattern = array_pattern;
+            lazy_pattern.lazy = true;
+            parser.tree.setData(pattern, .{ .array_pattern = lazy_pattern });
+        },
+        .object_pattern => |object_pattern| {
+            var lazy_pattern = object_pattern;
+            lazy_pattern.lazy = true;
+            parser.tree.setData(pattern, .{ .object_pattern = lazy_pattern });
+        },
+        else => unreachable,
+    }
+
+    parser.tree.setSpan(pattern, .{ .start = start, .end = span.end });
+}
+
+fn parseLazyBindingPattern(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(parser.current_token.tag == .bitwise_and);
+    const ampersand = parser.current_token;
+
+    if (!isLazyPatternStart(parser)) {
+        return parseLazyBindingPatternError(parser);
+    }
+
+    if (!parser.tree.isTsrx()) {
+        try parser.report(
+            ampersand.span,
+            "Lazy destructuring patterns are only enabled in TSRX files",
+            .{ .help = "Use a .tsrx file or remove the '&' lazy-pattern marker." },
+        );
+        return null;
+    }
+
+    try parser.advance() orelse return null;
+
+    const pattern = switch (parser.current_token.tag) {
+        .left_bracket => try parseArrayPattern(parser) orelse return null,
+        .left_brace => try parseObjectPattern(parser) orelse return null,
+        else => unreachable,
+    };
+    markLazyPattern(parser, pattern, ampersand.span.start);
+    return pattern;
+}
+
+fn parseLazyBindingPatternError(parser: *Parser) Error!?ast.NodeIndex {
+    const token = parser.current_token;
+    try parser.report(
+        token.span,
+        try parser.fmt(
+            "Unexpected token '{s}' in binding pattern",
+            .{parser.describeToken(token)},
+        ),
+        .{ .help = "Expected a contiguous TSRX lazy pattern introducer '&{' or '&['." },
+    );
+    return null;
 }
 
 fn parseArrayPattern(parser: *Parser) Error!?ast.NodeIndex {

--- a/src/parser/syntax/statements.zig
+++ b/src/parser/syntax/statements.zig
@@ -16,6 +16,7 @@ const for_loop = @import("for_loop.zig");
 const modules = @import("modules.zig");
 const ts_types = @import("ts/types.zig");
 const ts_decl = @import("ts/statements.zig");
+const tsrx = @import("tsrx/root.zig");
 
 const ParseStatementOpts = struct {
     /// true when parsing the body of `if`, `while`, `do`, `for`, `with`, or labeled statements,
@@ -76,6 +77,10 @@ pub fn parseStatement(parser: *Parser, opts: ParseStatementOpts) Error!?ast.Node
 /// `@dec class C` or `@dec export [default] class C`.
 fn parseDecoratedStatement(parser: *Parser) Error!?ast.NodeIndex {
     std.debug.assert(parser.current_token.tag == .at);
+
+    if (tsrx.isCodeBlockStart(parser)) return parseExpressionStatement(parser);
+    if (tsrx.isControlFlowDirectiveStart(parser)) return parseExpressionStatement(parser);
+
     const start = parser.current_token.span.start;
     const decorators = try extensions.parseDecorators(parser) orelse return null;
 

--- a/src/parser/syntax/tsrx/dynamic_tag.zig
+++ b/src/parser/syntax/tsrx/dynamic_tag.zig
@@ -1,0 +1,208 @@
+const std = @import("std");
+const ast = @import("../../ast.zig");
+const Parser = @import("../../parser.zig").Parser;
+const Error = @import("../../parser.zig").Error;
+
+const TsrxNodeWalkDepthMax: u32 = 64;
+
+pub fn validateExpression(
+    parser: *Parser,
+    container: ast.NodeIndex,
+) Error!void {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(container != .null);
+    std.debug.assert(parser.tree.data(container) == .jsx_expression_container);
+
+    if (isValidTsrxDynamicTagExpression(parser, container)) return;
+
+    try parser.report(
+        parser.tree.span(container),
+        "TSRX dynamic tag expression must resolve to an element name",
+        .{ .help = "Use an identifier, member expression, string literal, or conditional." },
+    );
+}
+
+fn isValidTsrxDynamicTagExpression(
+    parser: *const Parser,
+    container: ast.NodeIndex,
+) bool {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(container != .null);
+    std.debug.assert(parser.tree.data(container) == .jsx_expression_container);
+
+    var expression = parser.tree.data(container).jsx_expression_container.expression;
+    var depth: u32 = 0;
+    while (depth < TsrxNodeWalkDepthMax) : (depth += 1) {
+        if (expression == .null) return false;
+        switch (parser.tree.data(expression)) {
+            .ts_as_expression => |node| expression = node.expression,
+            .ts_type_assertion => |node| expression = node.expression,
+            .ts_non_null_expression => |node| expression = node.expression,
+            .parenthesized_expression => |node| expression = node.expression,
+            .chain_expression => |node| expression = node.expression,
+            else => break,
+        }
+    }
+
+    if (depth == TsrxNodeWalkDepthMax) return false;
+    std.debug.assert(expression != .null);
+
+    return switch (parser.tree.data(expression)) {
+        .identifier_reference => |node| !std.mem.eql(
+            u8,
+            parser.tree.string(node.name),
+            "undefined",
+        ),
+        .string_literal => true,
+        .template_literal => |node| node.expressions.len == 0,
+        .numeric_literal,
+        .bigint_literal,
+        .boolean_literal,
+        .null_literal,
+        .regexp_literal,
+        .jsx_element,
+        .jsx_fragment,
+        .jsx_style_element,
+        .jsx_code_block,
+        .jsx_if_expression,
+        .jsx_for_expression,
+        .jsx_switch_expression,
+        .jsx_try_expression,
+        .jsx_expression_container,
+        .jsx_empty_expression,
+        .jsx_text,
+        .jsx_spread_child,
+        => false,
+        .unary_expression => |node| if (node.operator == .void)
+            false
+        else
+            !tsrxDynamicTagContainsDisallowedSyntax(parser, expression, 0),
+        else => !tsrxDynamicTagContainsDisallowedSyntax(parser, expression, 0),
+    };
+}
+
+fn tsrxDynamicTagContainsDisallowedSyntax(
+    parser: *const Parser,
+    node: ast.NodeIndex,
+    depth: u32,
+) bool {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(depth <= TsrxNodeWalkDepthMax);
+
+    if (node == .null) return false;
+    if (depth == TsrxNodeWalkDepthMax) return true;
+
+    const next_depth = depth + 1;
+    return switch (parser.tree.data(node)) {
+        .spread_element,
+        .object_expression,
+        .array_expression,
+        .call_expression,
+        .new_expression,
+        .tagged_template_expression,
+        .import_expression,
+        .jsx_element,
+        .jsx_fragment,
+        .jsx_style_element,
+        .jsx_code_block,
+        .jsx_if_expression,
+        .jsx_for_expression,
+        .jsx_switch_expression,
+        .jsx_try_expression,
+        .jsx_expression_container,
+        .jsx_empty_expression,
+        .jsx_text,
+        .jsx_spread_child,
+        => true,
+        .template_literal => |template| template.expressions.len > 0,
+        .binary_expression => |expr| if (expr.operator == .add)
+            true
+        else
+            tsrxDynamicTagContainsDisallowedSyntax(parser, expr.left, next_depth) or
+                tsrxDynamicTagContainsDisallowedSyntax(parser, expr.right, next_depth),
+        .logical_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.left,
+            next_depth,
+        ) or tsrxDynamicTagContainsDisallowedSyntax(parser, expr.right, next_depth),
+        .conditional_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.@"test",
+            next_depth,
+        ) or tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.consequent,
+            next_depth,
+        ) or tsrxDynamicTagContainsDisallowedSyntax(parser, expr.alternate, next_depth),
+        .unary_expression => |expr| if (expr.operator == .void)
+            true
+        else
+            tsrxDynamicTagContainsDisallowedSyntax(parser, expr.argument, next_depth),
+        .update_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.argument,
+            next_depth,
+        ),
+        .assignment_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.left,
+            next_depth,
+        ) or tsrxDynamicTagContainsDisallowedSyntax(parser, expr.right, next_depth),
+        .sequence_expression => |expr| tsrxDynamicTagRangeContainsDisallowedSyntax(
+            parser,
+            expr.expressions,
+            next_depth,
+        ),
+        .member_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.object,
+            next_depth,
+        ) or tsrxDynamicTagContainsDisallowedSyntax(parser, expr.property, next_depth),
+        .chain_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.expression,
+            next_depth,
+        ),
+        .await_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.argument,
+            next_depth,
+        ),
+        .yield_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.argument,
+            next_depth,
+        ),
+        .parenthesized_expression => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.expression,
+            next_depth,
+        ),
+        inline .ts_as_expression,
+        .ts_satisfies_expression,
+        .ts_type_assertion,
+        .ts_non_null_expression,
+        .ts_instantiation_expression,
+        => |expr| tsrxDynamicTagContainsDisallowedSyntax(
+            parser,
+            expr.expression,
+            next_depth,
+        ),
+        else => false,
+    };
+}
+
+fn tsrxDynamicTagRangeContainsDisallowedSyntax(
+    parser: *const Parser,
+    nodes: ast.IndexRange,
+    depth: u32,
+) bool {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(depth <= TsrxNodeWalkDepthMax);
+    std.debug.assert(nodes.start + nodes.len <= parser.tree.extras.items.len);
+
+    for (parser.tree.extra(nodes)) |node| {
+        if (tsrxDynamicTagContainsDisallowedSyntax(parser, node, depth)) return true;
+    }
+    return false;
+}

--- a/src/parser/syntax/tsrx/root.zig
+++ b/src/parser/syntax/tsrx/root.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const TokenTag = @import("../../token.zig").TokenTag;
+const Parser = @import("../../parser.zig").Parser;
+
+pub fn isCodeBlockStart(parser: *Parser) bool {
+    std.debug.assert(parser.current_token.span.start <= parser.current_token.span.end);
+    std.debug.assert(parser.current_token.span.end <= parser.tree.source.len);
+
+    if (!parser.tree.isTsrx()) return false;
+    if (parser.current_token.tag != .at) return false;
+
+    const marker_end = parser.current_token.span.end;
+    const next = parser.peekAhead() orelse return false;
+    if (next.tag != .left_brace) return false;
+
+    return next.span.start == marker_end;
+}
+
+pub fn isIfDirectiveStart(parser: *Parser) bool {
+    return isDirectiveStart(parser, .@"if");
+}
+
+pub fn isForDirectiveStart(parser: *Parser) bool {
+    return isDirectiveStart(parser, .@"for");
+}
+
+pub fn isSwitchDirectiveStart(parser: *Parser) bool {
+    return isDirectiveStart(parser, .@"switch");
+}
+
+pub fn isTryDirectiveStart(parser: *Parser) bool {
+    return isDirectiveStart(parser, .@"try");
+}
+
+pub fn isElseDirectiveStart(parser: *Parser) bool {
+    return isDirectiveStart(parser, .@"else");
+}
+
+pub fn isEmptyDirectiveStart(parser: *Parser) bool {
+    return isIdentifierDirectiveStart(parser, "empty");
+}
+
+pub fn isCaseDirectiveStart(parser: *Parser) bool {
+    return isDirectiveStart(parser, .case);
+}
+
+pub fn isDefaultDirectiveStart(parser: *Parser) bool {
+    return isDirectiveStart(parser, .default);
+}
+
+pub fn isPendingDirectiveStart(parser: *Parser) bool {
+    return isIdentifierDirectiveStart(parser, "pending");
+}
+
+pub fn isCatchDirectiveStart(parser: *Parser) bool {
+    return isDirectiveStart(parser, .@"catch");
+}
+
+pub fn isControlFlowDirectiveStart(parser: *Parser) bool {
+    std.debug.assert(parser.current_token.span.start <= parser.current_token.span.end);
+    std.debug.assert(parser.current_token.span.end <= parser.tree.source.len);
+
+    if (!parser.tree.isTsrx()) return false;
+    if (parser.current_token.tag != .at) return false;
+
+    const marker_end = parser.current_token.span.end;
+    const next = parser.peekAhead() orelse return false;
+    if (next.span.start != marker_end) return false;
+
+    return switch (next.tag) {
+        .@"if",
+        .@"for",
+        .@"switch",
+        .@"try",
+        => true,
+        else => false,
+    };
+}
+
+fn isDirectiveStart(parser: *Parser, tag: TokenTag) bool {
+    std.debug.assert(parser.current_token.span.start <= parser.current_token.span.end);
+    std.debug.assert(parser.current_token.span.end <= parser.tree.source.len);
+
+    if (!parser.tree.isTsrx()) return false;
+    if (parser.current_token.tag != .at) return false;
+
+    const marker_end = parser.current_token.span.end;
+    const next = parser.peekAhead() orelse return false;
+    if (next.tag != tag) return false;
+
+    return next.span.start == marker_end;
+}
+
+fn isIdentifierDirectiveStart(parser: *Parser, text: []const u8) bool {
+    std.debug.assert(parser.current_token.span.start <= parser.current_token.span.end);
+    std.debug.assert(parser.current_token.span.end <= parser.tree.source.len);
+
+    if (!parser.tree.isTsrx()) return false;
+    if (parser.current_token.tag != .at) return false;
+
+    const marker_end = parser.current_token.span.end;
+    const text_end = marker_end + @as(u32, @intCast(text.len));
+    if (text_end > parser.tree.source.len) return false;
+    if (!std.mem.eql(u8, parser.tree.source[marker_end..text_end], text)) return false;
+
+    if (text_end == parser.tree.source.len) return true;
+
+    const next = parser.tree.source[text_end];
+    return !std.ascii.isAlphanumeric(next) and next != '_' and next != '$';
+}

--- a/src/parser/syntax/tsrx/template.zig
+++ b/src/parser/syntax/tsrx/template.zig
@@ -1,0 +1,882 @@
+const std = @import("std");
+const ast = @import("../../ast.zig");
+const Precedence = @import("../../token.zig").Precedence;
+const Parser = @import("../../parser.zig").Parser;
+const Error = @import("../../parser.zig").Error;
+
+const expressions = @import("../expressions.zig");
+const for_loop = @import("../for_loop.zig");
+const patterns = @import("../patterns.zig");
+const ts = @import("../ts/types.zig");
+const tsrx = @import("root.zig");
+
+const TsrxNodeWalkDepthMax: u32 = 64;
+
+pub fn parseCodeBlock(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(parser.current_token.tag == .at);
+    std.debug.assert(tsrx.isCodeBlockStart(parser));
+
+    const start = parser.current_token.span.start;
+
+    try parser.advance() orelse return null; // consume '@'
+
+    if (!try parser.expect(
+        .left_brace,
+        "Expected '{' after TSRX code block marker",
+        "TSRX code blocks are written '@{ ... }' with no whitespace after '@'",
+    )) return null;
+
+    const allow_return_statement = parser.context.@"return";
+    const parsed_body = blk: {
+        const saved_return = parser.context.@"return";
+        parser.context.@"return" = true;
+        defer parser.context.@"return" = saved_return;
+
+        break :blk try parser.parseBody(.right_brace, .other);
+    };
+    const code_block = try parseJsxCodeBlockBody(parser, parsed_body, .{
+        .allow_return_statement = allow_return_statement,
+    });
+
+    if (parser.current_token.tag != .right_brace) {
+        try parser.reportExpected(
+            parser.current_token.span,
+            "Expected '}' to close TSRX code block",
+            .{ .help = "Add '}' to close the '@{' block" },
+        );
+        return null;
+    }
+
+    const end = parser.current_token.span.end;
+    try parser.advance() orelse return null; // consume '}'
+
+    return try parser.tree.addNode(
+        .{ .jsx_code_block = code_block },
+        .{ .start = start, .end = end },
+    );
+}
+
+pub fn parseControlFlowExpression(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(parser.current_token.tag == .at);
+    std.debug.assert(tsrx.isControlFlowDirectiveStart(parser));
+
+    if (tsrx.isIfDirectiveStart(parser)) return parseTsrxIfExpression(parser);
+    if (tsrx.isForDirectiveStart(parser)) return parseTsrxForExpression(parser);
+    if (tsrx.isSwitchDirectiveStart(parser)) return parseTsrxSwitchExpression(parser);
+    if (tsrx.isTryDirectiveStart(parser)) return parseTsrxTryExpression(parser);
+
+    try parser.reportExpected(
+        parser.current_token.span,
+        "Expected supported TSRX control-flow directive",
+        .{ .help = "Supported TSRX directives are '@if', '@for', '@switch', and '@try'." },
+    );
+    return null;
+}
+
+fn parseTsrxIfExpression(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(tsrx.isIfDirectiveStart(parser));
+
+    const start = parser.current_token.span.start;
+    try parser.advance() orelse return null; // consume '@'
+
+    if (!try parser.expect(
+        .@"if",
+        "Expected 'if' after '@'",
+        "TSRX if directives are written '@if (...) { ... }'",
+    )) return null;
+
+    if (!try parser.expect(.left_paren, "Expected '(' after '@if'", null)) return null;
+
+    const condition = try expressions.parseExpression(parser, Precedence.Lowest, .{}) orelse
+        return null;
+
+    if (!try parser.expect(.right_paren, "Expected ')' after '@if' condition", null)) return null;
+
+    const consequent = try parseTsrxTemplateBlock(parser) orelse return null;
+
+    const alternate = if (tsrx.isElseDirectiveStart(parser)) blk: {
+        try parser.advance() orelse return null; // consume '@'
+        if (!try parser.expect(
+            .@"else",
+            "Expected 'else' after '@'",
+            "TSRX else clauses are written '@else { ... }'",
+        )) return null;
+
+        if (tsrx.isIfDirectiveStart(parser)) {
+            break :blk try parseTsrxIfExpression(parser) orelse return null;
+        }
+
+        break :blk try parseTsrxTemplateBlock(parser) orelse return null;
+    } else .null;
+
+    const end = if (alternate != .null)
+        parser.tree.span(alternate).end
+    else
+        parser.tree.span(consequent).end;
+
+    return try parser.tree.addNode(
+        .{ .jsx_if_expression = .{
+            .@"test" = condition,
+            .consequent = consequent,
+            .alternate = alternate,
+        } },
+        .{ .start = start, .end = end },
+    );
+}
+
+fn parseTsrxForExpression(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(tsrx.isForDirectiveStart(parser));
+
+    const start = parser.current_token.span.start;
+    try parser.advance() orelse return null; // consume '@'
+
+    const statement = try for_loop.parseForStatementWithBody(
+        parser,
+        false,
+        parseTsrxTemplateBlock,
+    ) orelse return null;
+
+    const empty = if (parser.current_token.tag == .at and tsrx.isEmptyDirectiveStart(parser)) blk: {
+        try parser.advance() orelse return null; // consume '@'
+        if (!try parser.expect(
+            .identifier,
+            "Expected 'empty' after '@'",
+            "TSRX empty clauses are written '@empty { ... }'",
+        )) return null;
+
+        break :blk try parseTsrxTemplateBlock(parser) orelse return null;
+    } else .null;
+
+    const end = if (empty != .null)
+        parser.tree.span(empty).end
+    else
+        parser.tree.span(statement).end;
+
+    return try parser.tree.addNode(
+        .{ .jsx_for_expression = .{
+            .statement = statement,
+            .empty = empty,
+        } },
+        .{ .start = start, .end = end },
+    );
+}
+
+fn parseTsrxTryExpression(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(tsrx.isTryDirectiveStart(parser));
+
+    const start = parser.current_token.span.start;
+    try parser.advance() orelse return null; // consume '@'
+
+    const try_start = parser.current_token.span.start;
+    if (!try parser.expect(
+        .@"try",
+        "Expected 'try' after '@'",
+        "TSRX try directives are written '@try { ... }'.",
+    )) return null;
+
+    const block = try parseTsrxTemplateBlock(parser) orelse return null;
+
+    const pending = if (parser.current_token.tag == .at and
+        tsrx.isPendingDirectiveStart(parser))
+    blk: {
+        try parser.advance() orelse return null; // consume '@'
+        if (!try parser.expect(
+            .identifier,
+            "Expected 'pending' after '@'",
+            "TSRX pending clauses are written '@pending { ... }'.",
+        )) return null;
+
+        break :blk try parseTsrxTemplateBlock(parser) orelse return null;
+    } else .null;
+
+    const handler = if (parser.current_token.tag == .at and
+        tsrx.isCatchDirectiveStart(parser))
+    blk: {
+        break :blk try parseTsrxCatchClause(parser) orelse return null;
+    } else .null;
+
+    if (pending == .null and handler == .null) {
+        try parser.report(
+            .{ .start = start, .end = parser.tree.span(block).end },
+            "TSRX try directive requires '@pending' or '@catch'",
+            .{},
+        );
+        return null;
+    }
+
+    const end = if (handler != .null)
+        parser.tree.span(handler).end
+    else if (pending != .null)
+        parser.tree.span(pending).end
+    else
+        parser.tree.span(block).end;
+
+    const statement = try parser.tree.addNode(
+        .{ .try_statement = .{
+            .block = block,
+            .handler = handler,
+            .finalizer = .null,
+        } },
+        .{ .start = try_start, .end = end },
+    );
+
+    return try parser.tree.addNode(
+        .{ .jsx_try_expression = .{
+            .statement = statement,
+            .pending = pending,
+        } },
+        .{ .start = start, .end = end },
+    );
+}
+
+fn parseTsrxCatchClause(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(tsrx.isCatchDirectiveStart(parser));
+
+    const start = parser.current_token.span.start;
+    try parser.advance() orelse return null; // consume '@'
+
+    if (!try parser.expect(
+        .@"catch",
+        "Expected 'catch' after '@'",
+        "TSRX catch clauses are written '@catch { ... }' or '@catch (error) { ... }'.",
+    )) return null;
+
+    var param: ast.NodeIndex = .null;
+    var reset_param: ast.NodeIndex = .null;
+    if (parser.current_token.tag == .left_paren) {
+        try parser.advance() orelse return null; // consume '('
+        param = try patterns.parseBindingPattern(parser) orelse return null;
+
+        if (parser.tree.isTs() and parser.current_token.tag == .colon) {
+            const annotation = try ts.parseTypeAnnotation(parser) orelse return null;
+            ts.applyTypeAnnotationToPattern(parser, param, annotation);
+        }
+
+        if (parser.current_token.tag == .comma) {
+            try parser.advance() orelse return null; // consume ','
+            reset_param = try patterns.parseBindingPattern(parser) orelse return null;
+
+            if (parser.tree.isTs() and parser.current_token.tag == .colon) {
+                const annotation = try ts.parseTypeAnnotation(parser) orelse return null;
+                ts.applyTypeAnnotationToPattern(parser, reset_param, annotation);
+            }
+        }
+
+        if (!try parser.expect(.right_paren, "Expected ')' after catch parameter", null))
+            return null;
+    }
+
+    const body = try parseTsrxTemplateBlock(parser) orelse return null;
+
+    return try parser.tree.addNode(
+        .{ .catch_clause = .{
+            .param = param,
+            .reset_param = reset_param,
+            .body = body,
+        } },
+        .{ .start = start, .end = parser.tree.span(body).end },
+    );
+}
+
+fn parseTsrxSwitchExpression(parser: *Parser) Error!?ast.NodeIndex {
+    std.debug.assert(tsrx.isSwitchDirectiveStart(parser));
+
+    const start = parser.current_token.span.start;
+    try parser.advance() orelse return null; // consume '@'
+
+    const switch_start = parser.current_token.span.start;
+    if (!try parser.expect(
+        .@"switch",
+        "Expected 'switch' after '@'",
+        "TSRX switch directives are written '@switch (...) { ... }'",
+    )) return null;
+
+    if (!try parser.expect(.left_paren, "Expected '(' after '@switch'", null)) return null;
+
+    const discriminant = try expressions.parseExpression(parser, Precedence.Lowest, .{}) orelse
+        return null;
+
+    if (!try parser.expect(
+        .right_paren,
+        "Expected ')' after '@switch' expression",
+        null,
+    )) return null;
+
+    if (!try parser.expect(
+        .left_brace,
+        "Expected '{' to start TSRX switch body",
+        "TSRX switch bodies contain '@case' and '@default' clauses.",
+    )) return null;
+
+    const cases = try parseTsrxSwitchCases(parser);
+
+    const switch_end = parser.current_token.span.end;
+    if (!try parser.expect(
+        .right_brace,
+        "Expected '}' to close TSRX switch body",
+        "Add '}' after the last TSRX switch clause.",
+    )) return null;
+
+    const statement = try parser.tree.addNode(
+        .{ .switch_statement = .{
+            .discriminant = discriminant,
+            .cases = cases,
+        } },
+        .{ .start = switch_start, .end = switch_end },
+    );
+
+    return try parser.tree.addNode(
+        .{ .jsx_switch_expression = .{ .statement = statement } },
+        .{ .start = start, .end = switch_end },
+    );
+}
+
+fn parseTsrxSwitchCases(parser: *Parser) Error!ast.IndexRange {
+    const checkpoint = parser.scratch_a.begin();
+    defer parser.scratch_a.reset(checkpoint);
+
+    var saw_default = false;
+    while (parser.current_token.tag != .right_brace and parser.current_token.tag != .eof) {
+        const case_node = try parseTsrxSwitchCase(parser, &saw_default) orelse return try parser.flushToExtras(&parser.scratch_a, checkpoint);
+        try parser.scratch_a.append(parser.allocator(), case_node);
+    }
+
+    return parser.flushToExtras(&parser.scratch_a, checkpoint);
+}
+
+fn parseTsrxSwitchCase(parser: *Parser, saw_default: *bool) Error!?ast.NodeIndex {
+    if (parser.current_token.tag != .at) {
+        try parser.reportExpected(
+            parser.current_token.span,
+            "Expected TSRX switch clause",
+            .{ .help = "Switch clauses are written '@case expr: { ... }' or '@default: { ... }'." },
+        );
+        return null;
+    }
+
+    const start = parser.current_token.span.start;
+    const is_default = tsrx.isDefaultDirectiveStart(parser);
+    if (!is_default and !tsrx.isCaseDirectiveStart(parser)) {
+        try parser.reportExpected(
+            parser.current_token.span,
+            "Expected TSRX switch clause",
+            .{ .help = "Switch clauses are written '@case expr: { ... }' or '@default: { ... }'." },
+        );
+        return null;
+    }
+
+    try parser.advance() orelse return null; // consume '@'
+
+    var test_expr: ast.NodeIndex = .null;
+    if (is_default) {
+        if (saw_default.*) {
+            try parser.report(parser.current_token.span, "Multiple default clauses", .{});
+        }
+        saw_default.* = true;
+        if (!try parser.expect(.default, "Expected 'default' after '@'", null)) return null;
+    } else {
+        if (!try parser.expect(.case, "Expected 'case' after '@'", null)) return null;
+        test_expr = try expressions.parseExpression(parser, Precedence.Lowest, .{}) orelse
+            return null;
+    }
+
+    if (!try parser.expect(.colon, "Expected ':' after TSRX switch clause", null)) return null;
+
+    const body = try parseTsrxTemplateBlockWithOptions(parser, .{
+        .allow_return_statement = true,
+    }) orelse return null;
+    const block = parser.tree.data(body).block_statement;
+    try validateTsrxSwitchCaseStatements(parser, block.body);
+
+    return try parser.tree.addNode(
+        .{ .switch_case = .{
+            .@"test" = test_expr,
+            .consequent = block.body,
+        } },
+        .{ .start = start, .end = parser.tree.span(body).end },
+    );
+}
+
+const ParseTsrxTemplateBlockOptions = struct {
+    allow_return_statement: bool = false,
+};
+
+fn parseTsrxTemplateBlock(parser: *Parser) Error!?ast.NodeIndex {
+    return parseTsrxTemplateBlockWithOptions(parser, .{});
+}
+
+fn parseTsrxTemplateBlockWithOptions(
+    parser: *Parser,
+    opts: ParseTsrxTemplateBlockOptions,
+) Error!?ast.NodeIndex {
+    const start = parser.current_token.span.start;
+
+    if (!try parser.expect(
+        .left_brace,
+        "Expected '{' after TSRX control-flow directive",
+        "TSRX control-flow bodies are written with braces.",
+    )) return null;
+
+    const parsed_body = blk: {
+        const saved_return = parser.context.@"return";
+        parser.context.@"return" = true;
+        defer parser.context.@"return" = saved_return;
+
+        break :blk try parser.parseBody(.right_brace, .other);
+    };
+    const body = try parseTsrxTemplateBlockBody(parser, parsed_body, .{
+        .allow_return_statement = opts.allow_return_statement,
+    });
+
+    const end = parser.current_token.span.end;
+    if (!try parser.expect(
+        .right_brace,
+        "Expected '}' to close TSRX control-flow block",
+        "Add '}' to close the control-flow block.",
+    )) return null;
+
+    return try parser.tree.addNode(
+        .{ .block_statement = .{ .body = body } },
+        .{ .start = start, .end = end },
+    );
+}
+
+const ParseJsxCodeBlockBodyOptions = struct {
+    allow_return_statement: bool = false,
+};
+
+fn parseTsrxTemplateBlockBody(
+    parser: *Parser,
+    parsed_body: ast.IndexRange,
+    opts: ParseJsxCodeBlockBodyOptions,
+) Error!ast.IndexRange {
+    const code_block = try parseJsxCodeBlockBody(parser, parsed_body, opts);
+
+    const checkpoint = parser.scratch_a.begin();
+    defer parser.scratch_a.reset(checkpoint);
+
+    for (parser.tree.extra(code_block.body)) |statement| {
+        try parser.scratch_a.append(parser.allocator(), statement);
+    }
+
+    if (code_block.render != .null) {
+        try parser.scratch_a.append(parser.allocator(), code_block.render);
+    }
+
+    return try parser.flushToExtras(&parser.scratch_a, checkpoint);
+}
+
+fn parseJsxCodeBlockBody(
+    parser: *Parser,
+    parsed_body: ast.IndexRange,
+    opts: ParseJsxCodeBlockBodyOptions,
+) Error!ast.JSXCodeBlock {
+    std.debug.assert(parser.tree.isTsrx());
+
+    const parsed_statements = parser.tree.extra(parsed_body);
+    std.debug.assert(parsed_statements.len == parsed_body.len);
+
+    var significant_count: u32 = parsed_body.len;
+
+    while (significant_count > 0) {
+        const statement = parsed_statements[significant_count - 1];
+        if (parser.tree.data(statement) != .empty_statement) break;
+        significant_count -= 1;
+    }
+
+    var render_seen = false;
+    var index: u32 = 0;
+    while (index < significant_count) : (index += 1) {
+        const statement = parsed_statements[index];
+        if (parseJsxCodeBlockRender(parser, statement) != .null) {
+            if (render_seen) {
+                try parser.report(
+                    parser.tree.span(statement),
+                    "A code block renders a single node",
+                    .{ .help = "Wrap multiple nodes or text in a fragment '<>...</>'." },
+                );
+            }
+            render_seen = true;
+        } else {
+            if (render_seen) {
+                try parser.report(
+                    parser.tree.span(statement),
+                    "Code must be at the top of '@{ }'",
+                    .{ .help = "Statements cannot follow the rendered output." },
+                );
+            }
+        }
+    }
+
+    var body = parsed_body;
+    body.len = significant_count;
+
+    if (significant_count == 0) {
+        return .{ .body = body, .render = .null };
+    }
+
+    const last_statement = parsed_statements[significant_count - 1];
+    const render = parseJsxCodeBlockRender(parser, last_statement);
+    if (render == .null) {
+        if (!opts.allow_return_statement) {
+            try validateTsrxTemplateReturnStatements(parser, body);
+        }
+        return .{ .body = body, .render = .null };
+    }
+
+    body.len -= 1;
+    if (!opts.allow_return_statement) {
+        try validateTsrxTemplateReturnStatements(parser, body);
+    }
+    return .{ .body = body, .render = render };
+}
+
+fn parseJsxCodeBlockRender(parser: *const Parser, statement: ast.NodeIndex) ast.NodeIndex {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(statement != .null);
+
+    switch (parser.tree.data(statement)) {
+        .expression_statement => |expr_stmt| {
+            if (parseJsxCodeBlockIsRenderOutput(parser, expr_stmt.expression)) {
+                return expr_stmt.expression;
+            }
+        },
+        else => {},
+    }
+
+    return .null;
+}
+
+fn parseJsxCodeBlockIsRenderOutput(parser: *const Parser, node: ast.NodeIndex) bool {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(node != .null);
+
+    return switch (parser.tree.data(node)) {
+        .jsx_element,
+        .jsx_fragment,
+        .jsx_style_element,
+        .jsx_code_block,
+        .jsx_if_expression,
+        .jsx_for_expression,
+        .jsx_switch_expression,
+        .jsx_try_expression,
+        => true,
+        else => false,
+    };
+}
+
+fn validateTsrxTemplateReturnStatements(
+    parser: *Parser,
+    statements: ast.IndexRange,
+) Error!void {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(statements.start + statements.len <= parser.tree.extras.items.len);
+
+    for (parser.tree.extra(statements)) |statement| {
+        try validateTsrxTemplateReturnStatement(parser, statement, false, 0);
+    }
+}
+
+fn validateTsrxTemplateReturnStatement(
+    parser: *Parser,
+    statement: ast.NodeIndex,
+    inside_loop: bool,
+    depth: u32,
+) Error!void {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(depth <= TsrxNodeWalkDepthMax);
+
+    if (statement == .null) return;
+    if (depth == TsrxNodeWalkDepthMax) {
+        try parser.report(
+            parser.tree.span(statement),
+            "TSRX template block is too deeply nested to validate",
+            .{},
+        );
+        return;
+    }
+
+    const next_depth = depth + 1;
+    switch (parser.tree.data(statement)) {
+        .return_statement => {
+            if (inside_loop) return;
+            try parser.report(
+                parser.tree.span(statement),
+                "`return` is invalid inside TSRX template blocks",
+                .{ .help = "Use rendered output as the final expression instead." },
+            );
+        },
+        .function,
+        .arrow_function_expression,
+        => return,
+        .block_statement => |block| try validateTsrxTemplateReturnRange(
+            parser,
+            block.body,
+            inside_loop,
+            next_depth,
+        ),
+        .if_statement => |stmt| {
+            try validateTsrxTemplateReturnStatement(
+                parser,
+                stmt.consequent,
+                inside_loop,
+                next_depth,
+            );
+            if (stmt.alternate != .null) {
+                try validateTsrxTemplateReturnStatement(
+                    parser,
+                    stmt.alternate,
+                    inside_loop,
+                    next_depth,
+                );
+            }
+        },
+        .switch_statement => |stmt| {
+            for (parser.tree.extra(stmt.cases)) |case_node| {
+                const case_data = parser.tree.data(case_node).switch_case;
+                try validateTsrxTemplateReturnRange(
+                    parser,
+                    case_data.consequent,
+                    inside_loop,
+                    next_depth,
+                );
+            }
+        },
+        .for_statement => |stmt| try validateTsrxTemplateReturnStatement(
+            parser,
+            stmt.body,
+            true,
+            next_depth,
+        ),
+        .for_in_statement => |stmt| try validateTsrxTemplateReturnStatement(
+            parser,
+            stmt.body,
+            true,
+            next_depth,
+        ),
+        .for_of_statement => |stmt| try validateTsrxTemplateReturnStatement(
+            parser,
+            stmt.body,
+            true,
+            next_depth,
+        ),
+        .while_statement => |stmt| try validateTsrxTemplateReturnStatement(
+            parser,
+            stmt.body,
+            true,
+            next_depth,
+        ),
+        .do_while_statement => |stmt| try validateTsrxTemplateReturnStatement(
+            parser,
+            stmt.body,
+            true,
+            next_depth,
+        ),
+        .labeled_statement => |stmt| try validateTsrxTemplateReturnStatement(
+            parser,
+            stmt.body,
+            inside_loop,
+            next_depth,
+        ),
+        .with_statement => |stmt| try validateTsrxTemplateReturnStatement(
+            parser,
+            stmt.body,
+            inside_loop,
+            next_depth,
+        ),
+        .try_statement => |stmt| {
+            try validateTsrxTemplateReturnStatement(
+                parser,
+                stmt.block,
+                inside_loop,
+                next_depth,
+            );
+            if (stmt.handler != .null) {
+                try validateTsrxTemplateReturnStatement(
+                    parser,
+                    stmt.handler,
+                    inside_loop,
+                    next_depth,
+                );
+            }
+            if (stmt.finalizer != .null) {
+                try validateTsrxTemplateReturnStatement(
+                    parser,
+                    stmt.finalizer,
+                    inside_loop,
+                    next_depth,
+                );
+            }
+        },
+        .catch_clause => |clause| try validateTsrxTemplateReturnStatement(
+            parser,
+            clause.body,
+            inside_loop,
+            next_depth,
+        ),
+        else => {},
+    }
+}
+
+fn validateTsrxTemplateReturnRange(
+    parser: *Parser,
+    statements: ast.IndexRange,
+    inside_loop: bool,
+    depth: u32,
+) Error!void {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(depth <= TsrxNodeWalkDepthMax);
+    std.debug.assert(statements.start + statements.len <= parser.tree.extras.items.len);
+
+    for (parser.tree.extra(statements)) |statement| {
+        try validateTsrxTemplateReturnStatement(parser, statement, inside_loop, depth);
+    }
+}
+
+fn validateTsrxSwitchCaseStatements(
+    parser: *Parser,
+    statements: ast.IndexRange,
+) Error!void {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(statements.start + statements.len <= parser.tree.extras.items.len);
+
+    try validateTsrxSwitchCaseRange(parser, statements, true, 0);
+}
+
+fn validateTsrxSwitchCaseRange(
+    parser: *Parser,
+    statements: ast.IndexRange,
+    report_break: bool,
+    depth: u32,
+) Error!void {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(depth <= TsrxNodeWalkDepthMax);
+    std.debug.assert(statements.start + statements.len <= parser.tree.extras.items.len);
+
+    for (parser.tree.extra(statements)) |statement| {
+        try validateTsrxSwitchCaseStatement(parser, statement, report_break, depth);
+    }
+}
+
+fn validateTsrxSwitchCaseStatement(
+    parser: *Parser,
+    statement: ast.NodeIndex,
+    report_break: bool,
+    depth: u32,
+) Error!void {
+    std.debug.assert(parser.tree.isTsrx());
+    std.debug.assert(depth <= TsrxNodeWalkDepthMax);
+
+    if (statement == .null) return;
+    if (depth == TsrxNodeWalkDepthMax) {
+        try parser.report(
+            parser.tree.span(statement),
+            "TSRX switch case is too deeply nested to validate",
+            .{},
+        );
+        return;
+    }
+
+    const next_depth = depth + 1;
+    switch (parser.tree.data(statement)) {
+        .break_statement => {
+            if (!report_break) return;
+            try parser.report(
+                parser.tree.span(statement),
+                "`break` is invalid inside `@switch` cases.",
+                .{},
+            );
+        },
+        .return_statement => try parser.report(
+            parser.tree.span(statement),
+            "`return` is invalid inside `@switch` cases.",
+            .{},
+        ),
+        .function,
+        .arrow_function_expression,
+        .for_statement,
+        .for_in_statement,
+        .for_of_statement,
+        .while_statement,
+        .do_while_statement,
+        => return,
+        .block_statement => |block| try validateTsrxSwitchCaseRange(
+            parser,
+            block.body,
+            report_break,
+            next_depth,
+        ),
+        .if_statement => |stmt| {
+            try validateTsrxSwitchCaseStatement(
+                parser,
+                stmt.consequent,
+                report_break,
+                next_depth,
+            );
+            if (stmt.alternate != .null) {
+                try validateTsrxSwitchCaseStatement(
+                    parser,
+                    stmt.alternate,
+                    report_break,
+                    next_depth,
+                );
+            }
+        },
+        .switch_statement => |stmt| {
+            for (parser.tree.extra(stmt.cases)) |case_node| {
+                const case_data = parser.tree.data(case_node).switch_case;
+                try validateTsrxSwitchCaseRange(
+                    parser,
+                    case_data.consequent,
+                    false,
+                    next_depth,
+                );
+            }
+        },
+        .labeled_statement => |stmt| try validateTsrxSwitchCaseStatement(
+            parser,
+            stmt.body,
+            report_break,
+            next_depth,
+        ),
+        .with_statement => |stmt| try validateTsrxSwitchCaseStatement(
+            parser,
+            stmt.body,
+            report_break,
+            next_depth,
+        ),
+        .try_statement => |stmt| {
+            try validateTsrxSwitchCaseStatement(
+                parser,
+                stmt.block,
+                report_break,
+                next_depth,
+            );
+            if (stmt.handler != .null) {
+                try validateTsrxSwitchCaseStatement(
+                    parser,
+                    stmt.handler,
+                    report_break,
+                    next_depth,
+                );
+            }
+            if (stmt.finalizer != .null) {
+                try validateTsrxSwitchCaseStatement(
+                    parser,
+                    stmt.finalizer,
+                    report_break,
+                    next_depth,
+                );
+            }
+        },
+        .catch_clause => |clause| try validateTsrxSwitchCaseStatement(
+            parser,
+            clause.body,
+            report_break,
+            next_depth,
+        ),
+        else => {},
+    }
+}

--- a/src/parser/syntax/variables.zig
+++ b/src/parser/syntax/variables.zig
@@ -203,6 +203,22 @@ pub fn canStartBinding(tag: TokenTag) bool {
     return tag.isIdentifierLike() or tag == .left_bracket or tag == .left_brace;
 }
 
+fn canStartLazyBinding(parser: *Parser, first: TokenTag) bool {
+    if (!parser.tree.isTsrx()) return false;
+    if (first != .bitwise_and) return false;
+
+    var peek = parser.beginPeek();
+    defer peek.end();
+
+    const ampersand = peek.next() orelse return false;
+    std.debug.assert(ampersand.tag == .bitwise_and);
+
+    const open = peek.next() orelse return false;
+    if (ampersand.span.end != open.span.start) return false;
+
+    return open.tag == .left_brace or open.tag == .left_bracket;
+}
+
 /// Determines if 'let' should be parsed as an identifier rather than a variable
 /// declaration keyword.
 pub fn isLetIdentifier(parser: *Parser) Error!?bool {
@@ -214,6 +230,8 @@ pub fn isLetIdentifier(parser: *Parser) Error!?bool {
     if (next.tag == .semicolon) {
         return true;
     }
+
+    if (canStartLazyBinding(parser, next.tag)) return false;
 
     // in single-statement contexts (eg, if/while bodies), parse `let` as an identifier
     // when the next token cannot start a lexical binding.

--- a/test/ast-helpers-for-test.ts
+++ b/test/ast-helpers-for-test.ts
@@ -323,7 +323,8 @@ export function formatDiagnostics(
       }
       prev = ln;
 
-      output.push(lineGutter(ln) + expandTabs(sourceLines[ln] ?? ""));
+      const sourceLine = expandTabs(sourceLines[ln] ?? "");
+      output.push(sourceLine.length > 0 ? lineGutter(ln) + sourceLine : `${pad(ln + 1)} |`);
 
       const lineM = markersByLine.get(ln);
       if (lineM && lineM.length > 0) {

--- a/test/codegen/print.test.ts
+++ b/test/codegen/print.test.ts
@@ -104,6 +104,201 @@ test("TS definite assignment assertions", () => {
   `);
 });
 
+test("TSRX lazy destructuring patterns keep their marker", () => {
+  expect(
+    gen("print", `let &{ title } = props;\nconst &[first] = values;`, {}, "input.tsrx"),
+  ).toMatchInlineSnapshot(`
+    "let &{ title } = props;
+    const &[first] = values;"
+  `);
+});
+
+test("TSRX code blocks print inside JSX children", () => {
+  expect(
+    gen("print", `const view = <section>@{ const label = "ready"; }</section>;`, {}, "input.tsrx"),
+  ).toMatchInlineSnapshot(`
+    "const view = <section>@{
+      const label = "ready";
+    }</section>;"
+  `);
+});
+
+test("TSRX code block render output prints after setup statements", () => {
+  expect(
+    gen(
+      "print",
+      `const view = <section>@{ const label = "ready"; <span>{label}</span> }</section>;`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "const view = <section>@{
+      const label = "ready";
+      <span>{label}</span>
+    }</section>;"
+  `);
+});
+
+test("TSRX code blocks print in expression position", () => {
+  expect(
+    gen(
+      "print",
+      `const value = @{ const label = "ready"; <span>{label}</span> };`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "const value = @{
+      const label = "ready";
+      <span>{label}</span>
+    };"
+  `);
+});
+
+test("TSRX code blocks print as function bodies", () => {
+  expect(
+    gen(
+      "print",
+      `function View(): unknown @{ const label = "ready"; <span>{label}</span> }`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "function View(): unknown @{
+      const label = "ready";
+      <span>{label}</span>
+    }"
+  `);
+});
+
+test("TSRX style elements print raw CSS", () => {
+  expect(
+    gen(
+      "print",
+      `const styles = <style>.card { color: red; }</style>;`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`"const styles = <style>.card { color: red; }</style>;"`);
+});
+
+test("TSRX code block render output can be a style element", () => {
+  expect(
+    gen(
+      "print",
+      `const styles = @{ const tone = "red"; <style>.card { color: red; }</style> };`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "const styles = @{
+      const tone = "red";
+      <style>.card { color: red; }</style>
+    };"
+  `);
+});
+
+test("JSX text escapes decoded character references", () => {
+  expect(
+    gen(
+      "print",
+      `const view = <p>&quot;&#x41;&#65;&amp;&lt;&gt;&apos;</p>;`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`"const view = <p>"AA&amp;&lt;>'</p>;"`);
+});
+
+test("TSRX submodule imports print identifier sources", () => {
+  expect(
+    gen(
+      "print",
+      `module server { export function load() {} }\nimport { load } from server;`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "module server {
+      export function load() {}
+    }
+    import { load } from server;"
+  `);
+});
+
+test("TSRX if control flow prints template blocks", () => {
+  expect(
+    gen(
+      "print",
+      `const view = @if (ready) { const label = "ready"; <span>{label}</span> } @else { <span /> };`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "const view = @if (ready) {
+      const label = "ready";
+      <span>{label}</span>
+    } @else {
+      <span />
+    };"
+  `);
+});
+
+test("TSRX for control flow prints template blocks", () => {
+  expect(
+    gen(
+      "print",
+      `const view = @for (const item of items; index itemIndex; key item.id) { <span>{item}</span> } @empty { <span /> };`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "const view = @for (const item of items; index itemIndex; key item.id) {
+      <span>{item}</span>
+    } @empty {
+      <span />
+    };"
+  `);
+});
+
+test("TSRX switch control flow prints template blocks", () => {
+  expect(
+    gen(
+      "print",
+      `const view = @switch (status) { @case "ready": { <span /> } @default: { <Fallback /> } };`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "const view = @switch (status) {
+      @case "ready": {
+        <span />
+      }
+      @default: {
+        <Fallback />
+      }
+    };"
+  `);
+});
+
+test("TSRX try control flow prints template blocks", () => {
+  expect(
+    gen(
+      "print",
+      `const view = @try { <Ready /> } @pending { <Spinner /> } @catch (error: Error, reset) { <Error retry={reset}>{error.message}</Error> };`,
+      {},
+      "input.tsrx",
+    ),
+  ).toMatchInlineSnapshot(`
+    "const view = @try {
+      <Ready />
+    } @pending {
+      <Spinner />
+    } @catch (error: Error, reset) {
+      <Error retry={reset}>{error.message}</Error>
+    };"
+  `);
+});
+
 test("TS leading union and intersection operators", () => {
   expect(
     gen(

--- a/test/corpus.ts
+++ b/test/corpus.ts
@@ -9,7 +9,7 @@ export const CORPUS_DIRS = [
   "test/parser/suite/ts/pass",
 ];
 
-const CORPUS_GLOB = "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}";
+const CORPUS_GLOB = "**/*.{js,jsx,ts,tsx,tsrx,mjs,cjs,mts,cts}";
 
 export interface CorpusFile {
   path: string;

--- a/test/parser/misc/comments/snapshots/catch-block-leading.snapshot.json
+++ b/test/parser/misc/comments/snapshots/catch-block-leading.snapshot.json
@@ -45,6 +45,7 @@
             "end": 23,
             "name": "e"
           },
+          "resetParam": null,
           "body": {
             "type": "BlockStatement",
             "start": 25,

--- a/test/parser/misc/ts/dynamic-tag-outside-tsrx.tsx
+++ b/test/parser/misc/ts/dynamic-tag-outside-tsrx.tsx
@@ -1,0 +1,3 @@
+const tag = "section";
+const value = <{tag} />;
+const fallback = value;

--- a/test/parser/misc/ts/lazy-destructuring-outside-tsrx.ts
+++ b/test/parser/misc/ts/lazy-destructuring-outside-tsrx.ts
@@ -1,0 +1,2 @@
+declare const props: { value: string };
+const &{ value } = props;

--- a/test/parser/misc/ts/snapshots/catch-type-annotation.snapshot.json
+++ b/test/parser/misc/ts/snapshots/catch-type-annotation.snapshot.json
@@ -62,6 +62,7 @@
             },
             "optional": false
           },
+          "resetParam": null,
           "body": {
             "type": "BlockStatement",
             "start": 44,

--- a/test/parser/misc/ts/snapshots/dynamic-tag-outside-tsrx.snapshot.json
+++ b/test/parser/misc/ts/snapshots/dynamic-tag-outside-tsrx.snapshot.json
@@ -1,0 +1,53 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 72,
+    "sourceType": "script",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 22,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 21,
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 9,
+              "name": "tag",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "Literal",
+              "start": 12,
+              "end": 21,
+              "value": "section",
+              "raw": "\"section\""
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": [
+    {
+      "severity": "error",
+      "message": "Expected JSX element name, but found '{'",
+      "start": 38,
+      "end": 39,
+      "help": "Dynamic JSX tag names are only enabled in TSRX files",
+      "labels": []
+    }
+  ]
+}

--- a/test/parser/misc/ts/snapshots/lazy-destructuring-outside-tsrx.snapshot.json
+++ b/test/parser/misc/ts/snapshots/lazy-destructuring-outside-tsrx.snapshot.json
@@ -1,0 +1,87 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 66,
+    "sourceType": "script",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 39,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 14,
+            "end": 38,
+            "id": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 38,
+              "name": "props",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 19,
+                "end": 38,
+                "typeAnnotation": {
+                  "type": "TSTypeLiteral",
+                  "start": 21,
+                  "end": 38,
+                  "members": [
+                    {
+                      "type": "TSPropertySignature",
+                      "start": 23,
+                      "end": 36,
+                      "key": {
+                        "type": "Identifier",
+                        "start": 23,
+                        "end": 28,
+                        "name": "value",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      "typeAnnotation": {
+                        "type": "TSTypeAnnotation",
+                        "start": 28,
+                        "end": 36,
+                        "typeAnnotation": {
+                          "type": "TSStringKeyword",
+                          "start": 30,
+                          "end": 36
+                        }
+                      },
+                      "computed": false,
+                      "optional": false,
+                      "readonly": false,
+                      "accessibility": null,
+                      "static": false
+                    }
+                  ]
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": [
+    {
+      "severity": "error",
+      "message": "Lazy destructuring patterns are only enabled in TSRX files",
+      "start": 46,
+      "end": 47,
+      "help": "Use a .tsrx file or remove the '&' lazy-pattern marker.",
+      "labels": []
+    }
+  ]
+}

--- a/test/parser/misc/ts/snapshots/submodule-import-outside-tsrx.snapshot.json
+++ b/test/parser/misc/ts/snapshots/submodule-import-outside-tsrx.snapshot.json
@@ -1,0 +1,21 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 29,
+    "sourceType": "script",
+    "hashbang": null,
+    "body": []
+  },
+  "comments": [],
+  "diagnostics": [
+    {
+      "severity": "error",
+      "message": "Identifier module specifiers require TSRX",
+      "start": 21,
+      "end": 27,
+      "help": "Use a .tsrx file for submodule imports such as import { load } from server.",
+      "labels": []
+    }
+  ]
+}

--- a/test/parser/misc/ts/submodule-import-outside-tsrx.ts
+++ b/test/parser/misc/ts/submodule-import-outside-tsrx.ts
@@ -1,0 +1,1 @@
+import { load } from server;

--- a/test/parser/misc/tsrx/code-block-expression.module.tsrx
+++ b/test/parser/misc/tsrx/code-block-expression.module.tsrx
@@ -1,0 +1,9 @@
+const value = @{ const label = "expr"; <span>{label}</span> };
+
+const nested = (
+    <section>
+        @{ const label = "outer"; @{ const inner = label; <span>{inner}</span> } }
+    </section>
+);
+
+export { value, nested };

--- a/test/parser/misc/tsrx/code-block-function.module.tsrx
+++ b/test/parser/misc/tsrx/code-block-function.module.tsrx
@@ -1,0 +1,5 @@
+function View(): unknown @{ const label = "fn"; <span>{label}</span> }
+
+const Arrow = (): unknown => @{ const label = "arrow"; <span>{label}</span> };
+
+export { View, Arrow };

--- a/test/parser/misc/tsrx/code-block.module.tsrx
+++ b/test/parser/misc/tsrx/code-block.module.tsrx
@@ -1,0 +1,15 @@
+const view = (
+    <section>
+        before
+        @{ const label = "ready"; const count = 1; }
+        after
+    </section>
+);
+
+const rendered = (
+    <section>
+        @{ const label = "ready"; <span>{label}</span> }
+    </section>
+);
+
+export { view, rendered };

--- a/test/parser/misc/tsrx/control-flow-for.module.tsrx
+++ b/test/parser/misc/tsrx/control-flow-for.module.tsrx
@@ -1,0 +1,25 @@
+declare const items: string[];
+declare const keyed: { id: string }[];
+
+const list = (
+    <section>
+        @for (const item of items) {
+            const label = item.toUpperCase();
+            <span>{label}</span>
+        } @empty {
+            <span>empty</span>
+        }
+    </section>
+);
+
+const indexed = @for (const item of items; index item_index) {
+    <span>{item_index}:{item}</span>
+};
+
+const keyed_list = @for (const item of keyed; index item_index; key item.id) {
+    <span>{item_index}:{item.id}</span>
+};
+
+const counted = @for (let i = 0; i < items.length; i++) {
+    <span>{items[i]}</span>
+};

--- a/test/parser/misc/tsrx/control-flow-if.module.tsrx
+++ b/test/parser/misc/tsrx/control-flow-if.module.tsrx
@@ -1,0 +1,28 @@
+declare const ready: boolean;
+declare const fallback: boolean;
+
+const child = (
+    <section>
+        @if (ready) {
+            const label = "ready";
+            <span>{label}</span>
+        } @else @if (fallback) {
+            <span>fallback</span>
+        } @else {
+            <span>empty</span>
+        }
+    </section>
+);
+
+const value = @if (ready) {
+    <span>yes</span>
+} @else {
+    <span>no</span>
+};
+
+const block = @{
+    const ok = ready;
+    @if (ok) {
+        <span>ok</span>
+    }
+};

--- a/test/parser/misc/tsrx/control-flow-switch-invalid.module.tsrx
+++ b/test/parser/misc/tsrx/control-flow-switch-invalid.module.tsrx
@@ -1,0 +1,18 @@
+declare const status: "ready" | "empty" | "loop";
+
+const view = @switch (status) {
+    @case "ready": {
+        break;
+    }
+    @case "empty": {
+        if (status) {
+            return <span>empty</span>;
+        }
+    }
+    @case "loop": {
+        for (const item of []) {
+            break;
+        }
+        <span>loop</span>
+    }
+};

--- a/test/parser/misc/tsrx/control-flow-switch.module.tsrx
+++ b/test/parser/misc/tsrx/control-flow-switch.module.tsrx
@@ -1,0 +1,27 @@
+declare const status: "ready" | "empty" | "error";
+
+const view = (
+    <section>
+        @switch (status) {
+            @case "ready": {
+                <span>ready</span>
+            }
+            @case "empty": {
+                const label = "empty";
+                <span>{label}</span>
+            }
+            @default: {
+                <span>error</span>
+            }
+        }
+    </section>
+);
+
+const value = @switch (status) {
+    @case "ready": {
+        <span>ready</span>
+    }
+    @default: {
+        <span>fallback</span>
+    }
+};

--- a/test/parser/misc/tsrx/control-flow-try.module.tsrx
+++ b/test/parser/misc/tsrx/control-flow-try.module.tsrx
@@ -1,0 +1,26 @@
+declare const ready: boolean;
+
+const view = (
+    <section>
+        @try {
+            const label = ready ? "ready" : "waiting";
+            <span>{label}</span>
+        } @pending {
+            <span>pending</span>
+        } @catch (error: Error, reset) {
+            <button onClick={reset}>{error.message}</button>
+        }
+    </section>
+);
+
+const pending_only = @try {
+    <span>ready</span>
+} @pending {
+    <span>pending</span>
+};
+
+const catch_only = @try {
+    <span>ready</span>
+} @catch {
+    <span>failed</span>
+};

--- a/test/parser/misc/tsrx/dynamic-tag-invalid.module.tsrx
+++ b/test/parser/misc/tsrx/dynamic-tag-invalid.module.tsrx
@@ -1,0 +1,9 @@
+declare const name: string;
+declare function getTag(): string;
+
+const call_tag = <{getTag()} />;
+const concat_tag = <{"x" + name} />;
+const interpolated_tag = <{`x${name}`} />;
+const object_tag = <{{ tag: "div" }} />;
+const undefined_tag = <{undefined} />;
+const void_tag = <{void 0} />;

--- a/test/parser/misc/tsrx/dynamic-tag.module.tsrx
+++ b/test/parser/misc/tsrx/dynamic-tag.module.tsrx
@@ -1,0 +1,17 @@
+type Tag = "section" | "article";
+
+export function Panel({ as, title }: { as: Tag; title: string }) {
+    return (
+        <{as} className="panel">
+            <h2>{title}</h2>
+        </{as}>
+    );
+}
+
+export const Icon = ({ as }: { as: Tag }) => <{as} />;
+
+export const WithWhitespace = ({ as }: { as: Tag }) => (
+    <{ as }>
+        <span />
+    </{as}>
+);

--- a/test/parser/misc/tsrx/lazy-destructuring.module.tsrx
+++ b/test/parser/misc/tsrx/lazy-destructuring.module.tsrx
@@ -1,0 +1,17 @@
+type Props = {
+    title: string;
+    count: number;
+};
+
+declare const props: Props;
+declare const values: string[];
+
+let &{ title, count: total = 0 } = props;
+const &[first, , ...rest] = values;
+
+&{ title } = props;
+&[first] = values;
+
+export function pick(&{ title: label }: Props) {
+    return label;
+}

--- a/test/parser/misc/tsrx/snapshots/code-block-expression.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/code-block-expression.snapshot.json
@@ -1,0 +1,379 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 223,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 62,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 61,
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 11,
+              "name": "value",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXCodeBlock",
+              "start": 14,
+              "end": 61,
+              "body": [
+                {
+                  "type": "VariableDeclaration",
+                  "start": 17,
+                  "end": 38,
+                  "kind": "const",
+                  "declarations": [
+                    {
+                      "type": "VariableDeclarator",
+                      "start": 23,
+                      "end": 37,
+                      "id": {
+                        "type": "Identifier",
+                        "start": 23,
+                        "end": 28,
+                        "name": "label",
+                        "decorators": [],
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "init": {
+                        "type": "Literal",
+                        "start": 31,
+                        "end": 37,
+                        "value": "expr",
+                        "raw": "\"expr\""
+                      },
+                      "definite": false
+                    }
+                  ],
+                  "declare": false
+                }
+              ],
+              "render": {
+                "type": "JSXElement",
+                "start": 39,
+                "end": 59,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 39,
+                  "end": 45,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 40,
+                    "end": 44,
+                    "name": "span"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXExpressionContainer",
+                    "start": 45,
+                    "end": 52,
+                    "expression": {
+                      "type": "Identifier",
+                      "start": 46,
+                      "end": 51,
+                      "name": "label",
+                      "decorators": [],
+                      "optional": false,
+                      "typeAnnotation": null
+                    }
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 52,
+                  "end": 59,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 54,
+                    "end": 58,
+                    "name": "span"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 64,
+        "end": 195,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 70,
+            "end": 194,
+            "id": {
+              "type": "Identifier",
+              "start": 70,
+              "end": 76,
+              "name": "nested",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 79,
+              "end": 194,
+              "expression": {
+                "type": "JSXElement",
+                "start": 85,
+                "end": 192,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 85,
+                  "end": 94,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 86,
+                    "end": 93,
+                    "name": "section"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 94,
+                    "end": 103,
+                    "value": "\n        ",
+                    "raw": "\n        "
+                  },
+                  {
+                    "type": "JSXCodeBlock",
+                    "start": 103,
+                    "end": 177,
+                    "body": [
+                      {
+                        "type": "VariableDeclaration",
+                        "start": 106,
+                        "end": 128,
+                        "kind": "const",
+                        "declarations": [
+                          {
+                            "type": "VariableDeclarator",
+                            "start": 112,
+                            "end": 127,
+                            "id": {
+                              "type": "Identifier",
+                              "start": 112,
+                              "end": 117,
+                              "name": "label",
+                              "decorators": [],
+                              "typeAnnotation": null,
+                              "optional": false
+                            },
+                            "init": {
+                              "type": "Literal",
+                              "start": 120,
+                              "end": 127,
+                              "value": "outer",
+                              "raw": "\"outer\""
+                            },
+                            "definite": false
+                          }
+                        ],
+                        "declare": false
+                      }
+                    ],
+                    "render": {
+                      "type": "JSXCodeBlock",
+                      "start": 129,
+                      "end": 175,
+                      "body": [
+                        {
+                          "type": "VariableDeclaration",
+                          "start": 132,
+                          "end": 152,
+                          "kind": "const",
+                          "declarations": [
+                            {
+                              "type": "VariableDeclarator",
+                              "start": 138,
+                              "end": 151,
+                              "id": {
+                                "type": "Identifier",
+                                "start": 138,
+                                "end": 143,
+                                "name": "inner",
+                                "decorators": [],
+                                "typeAnnotation": null,
+                                "optional": false
+                              },
+                              "init": {
+                                "type": "Identifier",
+                                "start": 146,
+                                "end": 151,
+                                "name": "label",
+                                "decorators": [],
+                                "optional": false,
+                                "typeAnnotation": null
+                              },
+                              "definite": false
+                            }
+                          ],
+                          "declare": false
+                        }
+                      ],
+                      "render": {
+                        "type": "JSXElement",
+                        "start": 153,
+                        "end": 173,
+                        "openingElement": {
+                          "type": "JSXOpeningElement",
+                          "start": 153,
+                          "end": 159,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 154,
+                            "end": 158,
+                            "name": "span"
+                          },
+                          "attributes": [],
+                          "selfClosing": false,
+                          "typeArguments": null
+                        },
+                        "children": [
+                          {
+                            "type": "JSXExpressionContainer",
+                            "start": 159,
+                            "end": 166,
+                            "expression": {
+                              "type": "Identifier",
+                              "start": 160,
+                              "end": 165,
+                              "name": "inner",
+                              "decorators": [],
+                              "optional": false,
+                              "typeAnnotation": null
+                            }
+                          }
+                        ],
+                        "closingElement": {
+                          "type": "JSXClosingElement",
+                          "start": 166,
+                          "end": 173,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 168,
+                            "end": 172,
+                            "name": "span"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 177,
+                    "end": 182,
+                    "value": "\n    ",
+                    "raw": "\n    "
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 182,
+                  "end": 192,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 184,
+                    "end": 191,
+                    "name": "section"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 197,
+        "end": 222,
+        "declaration": null,
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 206,
+            "end": 211,
+            "local": {
+              "type": "Identifier",
+              "start": 206,
+              "end": 211,
+              "name": "value",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 206,
+              "end": 211,
+              "name": "value",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          },
+          {
+            "type": "ExportSpecifier",
+            "start": 213,
+            "end": 219,
+            "local": {
+              "type": "Identifier",
+              "start": 213,
+              "end": 219,
+              "name": "nested",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 213,
+              "end": 219,
+              "name": "nested",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          }
+        ],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/code-block-function.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/code-block-function.snapshot.json
@@ -1,0 +1,315 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 176,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 70,
+        "id": {
+          "type": "Identifier",
+          "start": 9,
+          "end": 13,
+          "name": "View",
+          "decorators": [],
+          "typeAnnotation": null,
+          "optional": false
+        },
+        "generator": false,
+        "async": false,
+        "params": [],
+        "body": {
+          "type": "JSXCodeBlock",
+          "start": 25,
+          "end": 70,
+          "body": [
+            {
+              "type": "VariableDeclaration",
+              "start": 28,
+              "end": 47,
+              "kind": "const",
+              "declarations": [
+                {
+                  "type": "VariableDeclarator",
+                  "start": 34,
+                  "end": 46,
+                  "id": {
+                    "type": "Identifier",
+                    "start": 34,
+                    "end": 39,
+                    "name": "label",
+                    "decorators": [],
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "init": {
+                    "type": "Literal",
+                    "start": 42,
+                    "end": 46,
+                    "value": "fn",
+                    "raw": "\"fn\""
+                  },
+                  "definite": false
+                }
+              ],
+              "declare": false
+            }
+          ],
+          "render": {
+            "type": "JSXElement",
+            "start": 48,
+            "end": 68,
+            "openingElement": {
+              "type": "JSXOpeningElement",
+              "start": 48,
+              "end": 54,
+              "name": {
+                "type": "JSXIdentifier",
+                "start": 49,
+                "end": 53,
+                "name": "span"
+              },
+              "attributes": [],
+              "selfClosing": false,
+              "typeArguments": null
+            },
+            "children": [
+              {
+                "type": "JSXExpressionContainer",
+                "start": 54,
+                "end": 61,
+                "expression": {
+                  "type": "Identifier",
+                  "start": 55,
+                  "end": 60,
+                  "name": "label",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                }
+              }
+            ],
+            "closingElement": {
+              "type": "JSXClosingElement",
+              "start": 61,
+              "end": 68,
+              "name": {
+                "type": "JSXIdentifier",
+                "start": 63,
+                "end": 67,
+                "name": "span"
+              }
+            }
+          }
+        },
+        "expression": false,
+        "typeParameters": null,
+        "returnType": {
+          "type": "TSTypeAnnotation",
+          "start": 15,
+          "end": 24,
+          "typeAnnotation": {
+            "type": "TSUnknownKeyword",
+            "start": 17,
+            "end": 24
+          }
+        },
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 72,
+        "end": 150,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 78,
+            "end": 149,
+            "id": {
+              "type": "Identifier",
+              "start": 78,
+              "end": 83,
+              "name": "Arrow",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ArrowFunctionExpression",
+              "start": 86,
+              "end": 149,
+              "id": null,
+              "generator": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "JSXCodeBlock",
+                "start": 101,
+                "end": 149,
+                "body": [
+                  {
+                    "type": "VariableDeclaration",
+                    "start": 104,
+                    "end": 126,
+                    "kind": "const",
+                    "declarations": [
+                      {
+                        "type": "VariableDeclarator",
+                        "start": 110,
+                        "end": 125,
+                        "id": {
+                          "type": "Identifier",
+                          "start": 110,
+                          "end": 115,
+                          "name": "label",
+                          "decorators": [],
+                          "typeAnnotation": null,
+                          "optional": false
+                        },
+                        "init": {
+                          "type": "Literal",
+                          "start": 118,
+                          "end": 125,
+                          "value": "arrow",
+                          "raw": "\"arrow\""
+                        },
+                        "definite": false
+                      }
+                    ],
+                    "declare": false
+                  }
+                ],
+                "render": {
+                  "type": "JSXElement",
+                  "start": 127,
+                  "end": 147,
+                  "openingElement": {
+                    "type": "JSXOpeningElement",
+                    "start": 127,
+                    "end": 133,
+                    "name": {
+                      "type": "JSXIdentifier",
+                      "start": 128,
+                      "end": 132,
+                      "name": "span"
+                    },
+                    "attributes": [],
+                    "selfClosing": false,
+                    "typeArguments": null
+                  },
+                  "children": [
+                    {
+                      "type": "JSXExpressionContainer",
+                      "start": 133,
+                      "end": 140,
+                      "expression": {
+                        "type": "Identifier",
+                        "start": 134,
+                        "end": 139,
+                        "name": "label",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      }
+                    }
+                  ],
+                  "closingElement": {
+                    "type": "JSXClosingElement",
+                    "start": 140,
+                    "end": 147,
+                    "name": {
+                      "type": "JSXIdentifier",
+                      "start": 142,
+                      "end": 146,
+                      "name": "span"
+                    }
+                  }
+                }
+              },
+              "expression": true,
+              "typeParameters": null,
+              "returnType": {
+                "type": "TSTypeAnnotation",
+                "start": 88,
+                "end": 97,
+                "typeAnnotation": {
+                  "type": "TSUnknownKeyword",
+                  "start": 90,
+                  "end": 97
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 152,
+        "end": 175,
+        "declaration": null,
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 161,
+            "end": 165,
+            "local": {
+              "type": "Identifier",
+              "start": 161,
+              "end": 165,
+              "name": "View",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 161,
+              "end": 165,
+              "name": "View",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          },
+          {
+            "type": "ExportSpecifier",
+            "start": 167,
+            "end": 172,
+            "local": {
+              "type": "Identifier",
+              "start": 167,
+              "end": 172,
+              "name": "Arrow",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 167,
+              "end": 172,
+              "name": "Arrow",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          }
+        ],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/code-block.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/code-block.snapshot.json
@@ -1,0 +1,376 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 266,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 128,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 127,
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 10,
+              "name": "view",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 13,
+              "end": 127,
+              "expression": {
+                "type": "JSXElement",
+                "start": 19,
+                "end": 125,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 19,
+                  "end": 28,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 20,
+                    "end": 27,
+                    "name": "section"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 28,
+                    "end": 52,
+                    "value": "\n        before\n        ",
+                    "raw": "\n        before\n        "
+                  },
+                  {
+                    "type": "JSXCodeBlock",
+                    "start": 52,
+                    "end": 96,
+                    "body": [
+                      {
+                        "type": "VariableDeclaration",
+                        "start": 55,
+                        "end": 77,
+                        "kind": "const",
+                        "declarations": [
+                          {
+                            "type": "VariableDeclarator",
+                            "start": 61,
+                            "end": 76,
+                            "id": {
+                              "type": "Identifier",
+                              "start": 61,
+                              "end": 66,
+                              "name": "label",
+                              "decorators": [],
+                              "typeAnnotation": null,
+                              "optional": false
+                            },
+                            "init": {
+                              "type": "Literal",
+                              "start": 69,
+                              "end": 76,
+                              "value": "ready",
+                              "raw": "\"ready\""
+                            },
+                            "definite": false
+                          }
+                        ],
+                        "declare": false
+                      },
+                      {
+                        "type": "VariableDeclaration",
+                        "start": 78,
+                        "end": 94,
+                        "kind": "const",
+                        "declarations": [
+                          {
+                            "type": "VariableDeclarator",
+                            "start": 84,
+                            "end": 93,
+                            "id": {
+                              "type": "Identifier",
+                              "start": 84,
+                              "end": 89,
+                              "name": "count",
+                              "decorators": [],
+                              "typeAnnotation": null,
+                              "optional": false
+                            },
+                            "init": {
+                              "type": "Literal",
+                              "start": 92,
+                              "end": 93,
+                              "value": 1,
+                              "raw": "1"
+                            },
+                            "definite": false
+                          }
+                        ],
+                        "declare": false
+                      }
+                    ],
+                    "render": null
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 96,
+                    "end": 115,
+                    "value": "\n        after\n    ",
+                    "raw": "\n        after\n    "
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 115,
+                  "end": 125,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 117,
+                    "end": 124,
+                    "name": "section"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 130,
+        "end": 237,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 136,
+            "end": 236,
+            "id": {
+              "type": "Identifier",
+              "start": 136,
+              "end": 144,
+              "name": "rendered",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 147,
+              "end": 236,
+              "expression": {
+                "type": "JSXElement",
+                "start": 153,
+                "end": 234,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 153,
+                  "end": 162,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 154,
+                    "end": 161,
+                    "name": "section"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 162,
+                    "end": 171,
+                    "value": "\n        ",
+                    "raw": "\n        "
+                  },
+                  {
+                    "type": "JSXCodeBlock",
+                    "start": 171,
+                    "end": 219,
+                    "body": [
+                      {
+                        "type": "VariableDeclaration",
+                        "start": 174,
+                        "end": 196,
+                        "kind": "const",
+                        "declarations": [
+                          {
+                            "type": "VariableDeclarator",
+                            "start": 180,
+                            "end": 195,
+                            "id": {
+                              "type": "Identifier",
+                              "start": 180,
+                              "end": 185,
+                              "name": "label",
+                              "decorators": [],
+                              "typeAnnotation": null,
+                              "optional": false
+                            },
+                            "init": {
+                              "type": "Literal",
+                              "start": 188,
+                              "end": 195,
+                              "value": "ready",
+                              "raw": "\"ready\""
+                            },
+                            "definite": false
+                          }
+                        ],
+                        "declare": false
+                      }
+                    ],
+                    "render": {
+                      "type": "JSXElement",
+                      "start": 197,
+                      "end": 217,
+                      "openingElement": {
+                        "type": "JSXOpeningElement",
+                        "start": 197,
+                        "end": 203,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 198,
+                          "end": 202,
+                          "name": "span"
+                        },
+                        "attributes": [],
+                        "selfClosing": false,
+                        "typeArguments": null
+                      },
+                      "children": [
+                        {
+                          "type": "JSXExpressionContainer",
+                          "start": 203,
+                          "end": 210,
+                          "expression": {
+                            "type": "Identifier",
+                            "start": 204,
+                            "end": 209,
+                            "name": "label",
+                            "decorators": [],
+                            "optional": false,
+                            "typeAnnotation": null
+                          }
+                        }
+                      ],
+                      "closingElement": {
+                        "type": "JSXClosingElement",
+                        "start": 210,
+                        "end": 217,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 212,
+                          "end": 216,
+                          "name": "span"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 219,
+                    "end": 224,
+                    "value": "\n    ",
+                    "raw": "\n    "
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 224,
+                  "end": 234,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 226,
+                    "end": 233,
+                    "name": "section"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 239,
+        "end": 265,
+        "declaration": null,
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 248,
+            "end": 252,
+            "local": {
+              "type": "Identifier",
+              "start": 248,
+              "end": 252,
+              "name": "view",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 248,
+              "end": 252,
+              "name": "view",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          },
+          {
+            "type": "ExportSpecifier",
+            "start": 254,
+            "end": 262,
+            "local": {
+              "type": "Identifier",
+              "start": 254,
+              "end": 262,
+              "name": "rendered",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 254,
+              "end": 262,
+              "name": "rendered",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          }
+        ],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/control-flow-for.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/control-flow-for.snapshot.json
@@ -1,0 +1,939 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 611,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 30,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 14,
+            "end": 29,
+            "id": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 29,
+              "name": "items",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 19,
+                "end": 29,
+                "typeAnnotation": {
+                  "type": "TSArrayType",
+                  "start": 21,
+                  "end": 29,
+                  "elementType": {
+                    "type": "TSStringKeyword",
+                    "start": 21,
+                    "end": 27
+                  }
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 31,
+        "end": 69,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 45,
+            "end": 68,
+            "id": {
+              "type": "Identifier",
+              "start": 45,
+              "end": 68,
+              "name": "keyed",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 50,
+                "end": 68,
+                "typeAnnotation": {
+                  "type": "TSArrayType",
+                  "start": 52,
+                  "end": 68,
+                  "elementType": {
+                    "type": "TSTypeLiteral",
+                    "start": 52,
+                    "end": 66,
+                    "members": [
+                      {
+                        "type": "TSPropertySignature",
+                        "start": 54,
+                        "end": 64,
+                        "key": {
+                          "type": "Identifier",
+                          "start": 54,
+                          "end": 56,
+                          "name": "id",
+                          "decorators": [],
+                          "optional": false,
+                          "typeAnnotation": null
+                        },
+                        "typeAnnotation": {
+                          "type": "TSTypeAnnotation",
+                          "start": 56,
+                          "end": 64,
+                          "typeAnnotation": {
+                            "type": "TSStringKeyword",
+                            "start": 58,
+                            "end": 64
+                          }
+                        },
+                        "computed": false,
+                        "optional": false,
+                        "readonly": false,
+                        "accessibility": null,
+                        "static": false
+                      }
+                    ]
+                  }
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 71,
+        "end": 293,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 77,
+            "end": 292,
+            "id": {
+              "type": "Identifier",
+              "start": 77,
+              "end": 81,
+              "name": "list",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 84,
+              "end": 292,
+              "expression": {
+                "type": "JSXElement",
+                "start": 90,
+                "end": 290,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 90,
+                  "end": 99,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 91,
+                    "end": 98,
+                    "name": "section"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 99,
+                    "end": 108,
+                    "value": "\n        ",
+                    "raw": "\n        "
+                  },
+                  {
+                    "type": "JSXForExpression",
+                    "start": 108,
+                    "end": 275,
+                    "statement": {
+                      "type": "ForOfStatement",
+                      "start": 109,
+                      "end": 225,
+                      "left": {
+                        "type": "VariableDeclaration",
+                        "start": 114,
+                        "end": 124,
+                        "kind": "const",
+                        "declarations": [
+                          {
+                            "type": "VariableDeclarator",
+                            "start": 120,
+                            "end": 124,
+                            "id": {
+                              "type": "Identifier",
+                              "start": 120,
+                              "end": 124,
+                              "name": "item",
+                              "decorators": [],
+                              "typeAnnotation": null,
+                              "optional": false
+                            },
+                            "init": null,
+                            "definite": false
+                          }
+                        ],
+                        "declare": false
+                      },
+                      "right": {
+                        "type": "Identifier",
+                        "start": 128,
+                        "end": 133,
+                        "name": "items",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      "body": {
+                        "type": "BlockStatement",
+                        "start": 135,
+                        "end": 225,
+                        "body": [
+                          {
+                            "type": "VariableDeclaration",
+                            "start": 149,
+                            "end": 182,
+                            "kind": "const",
+                            "declarations": [
+                              {
+                                "type": "VariableDeclarator",
+                                "start": 155,
+                                "end": 181,
+                                "id": {
+                                  "type": "Identifier",
+                                  "start": 155,
+                                  "end": 160,
+                                  "name": "label",
+                                  "decorators": [],
+                                  "typeAnnotation": null,
+                                  "optional": false
+                                },
+                                "init": {
+                                  "type": "CallExpression",
+                                  "start": 163,
+                                  "end": 181,
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 163,
+                                    "end": 179,
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 163,
+                                      "end": 167,
+                                      "name": "item",
+                                      "decorators": [],
+                                      "optional": false,
+                                      "typeAnnotation": null
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 168,
+                                      "end": 179,
+                                      "name": "toUpperCase",
+                                      "decorators": [],
+                                      "optional": false,
+                                      "typeAnnotation": null
+                                    },
+                                    "computed": false,
+                                    "optional": false
+                                  },
+                                  "arguments": [],
+                                  "optional": false,
+                                  "typeArguments": null
+                                },
+                                "definite": false
+                              }
+                            ],
+                            "declare": false
+                          },
+                          {
+                            "type": "JSXElement",
+                            "start": 195,
+                            "end": 215,
+                            "openingElement": {
+                              "type": "JSXOpeningElement",
+                              "start": 195,
+                              "end": 201,
+                              "name": {
+                                "type": "JSXIdentifier",
+                                "start": 196,
+                                "end": 200,
+                                "name": "span"
+                              },
+                              "attributes": [],
+                              "selfClosing": false,
+                              "typeArguments": null
+                            },
+                            "children": [
+                              {
+                                "type": "JSXExpressionContainer",
+                                "start": 201,
+                                "end": 208,
+                                "expression": {
+                                  "type": "Identifier",
+                                  "start": 202,
+                                  "end": 207,
+                                  "name": "label",
+                                  "decorators": [],
+                                  "optional": false,
+                                  "typeAnnotation": null
+                                }
+                              }
+                            ],
+                            "closingElement": {
+                              "type": "JSXClosingElement",
+                              "start": 208,
+                              "end": 215,
+                              "name": {
+                                "type": "JSXIdentifier",
+                                "start": 210,
+                                "end": 214,
+                                "name": "span"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "await": false,
+                      "index": null,
+                      "key": null
+                    },
+                    "empty": {
+                      "type": "BlockStatement",
+                      "start": 233,
+                      "end": 275,
+                      "body": [
+                        {
+                          "type": "JSXElement",
+                          "start": 247,
+                          "end": 265,
+                          "openingElement": {
+                            "type": "JSXOpeningElement",
+                            "start": 247,
+                            "end": 253,
+                            "name": {
+                              "type": "JSXIdentifier",
+                              "start": 248,
+                              "end": 252,
+                              "name": "span"
+                            },
+                            "attributes": [],
+                            "selfClosing": false,
+                            "typeArguments": null
+                          },
+                          "children": [
+                            {
+                              "type": "JSXText",
+                              "start": 253,
+                              "end": 258,
+                              "value": "empty",
+                              "raw": "empty"
+                            }
+                          ],
+                          "closingElement": {
+                            "type": "JSXClosingElement",
+                            "start": 258,
+                            "end": 265,
+                            "name": {
+                              "type": "JSXIdentifier",
+                              "start": 260,
+                              "end": 264,
+                              "name": "span"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 275,
+                    "end": 280,
+                    "value": "\n    ",
+                    "raw": "\n    "
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 280,
+                  "end": 290,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 282,
+                    "end": 289,
+                    "name": "section"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 295,
+        "end": 397,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 301,
+            "end": 396,
+            "id": {
+              "type": "Identifier",
+              "start": 301,
+              "end": 308,
+              "name": "indexed",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXForExpression",
+              "start": 311,
+              "end": 396,
+              "statement": {
+                "type": "ForOfStatement",
+                "start": 312,
+                "end": 396,
+                "left": {
+                  "type": "VariableDeclaration",
+                  "start": 317,
+                  "end": 327,
+                  "kind": "const",
+                  "declarations": [
+                    {
+                      "type": "VariableDeclarator",
+                      "start": 323,
+                      "end": 327,
+                      "id": {
+                        "type": "Identifier",
+                        "start": 323,
+                        "end": 327,
+                        "name": "item",
+                        "decorators": [],
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "init": null,
+                      "definite": false
+                    }
+                  ],
+                  "declare": false
+                },
+                "right": {
+                  "type": "Identifier",
+                  "start": 331,
+                  "end": 336,
+                  "name": "items",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 356,
+                  "end": 396,
+                  "body": [
+                    {
+                      "type": "JSXElement",
+                      "start": 362,
+                      "end": 394,
+                      "openingElement": {
+                        "type": "JSXOpeningElement",
+                        "start": 362,
+                        "end": 368,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 363,
+                          "end": 367,
+                          "name": "span"
+                        },
+                        "attributes": [],
+                        "selfClosing": false,
+                        "typeArguments": null
+                      },
+                      "children": [
+                        {
+                          "type": "JSXExpressionContainer",
+                          "start": 368,
+                          "end": 380,
+                          "expression": {
+                            "type": "Identifier",
+                            "start": 369,
+                            "end": 379,
+                            "name": "item_index",
+                            "decorators": [],
+                            "optional": false,
+                            "typeAnnotation": null
+                          }
+                        },
+                        {
+                          "type": "JSXText",
+                          "start": 380,
+                          "end": 381,
+                          "value": ":",
+                          "raw": ":"
+                        },
+                        {
+                          "type": "JSXExpressionContainer",
+                          "start": 381,
+                          "end": 387,
+                          "expression": {
+                            "type": "Identifier",
+                            "start": 382,
+                            "end": 386,
+                            "name": "item",
+                            "decorators": [],
+                            "optional": false,
+                            "typeAnnotation": null
+                          }
+                        }
+                      ],
+                      "closingElement": {
+                        "type": "JSXClosingElement",
+                        "start": 387,
+                        "end": 394,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 389,
+                          "end": 393,
+                          "name": "span"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "await": false,
+                "index": {
+                  "type": "Identifier",
+                  "start": 344,
+                  "end": 354,
+                  "name": "item_index",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "key": null
+              },
+              "empty": null
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 399,
+        "end": 520,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 405,
+            "end": 519,
+            "id": {
+              "type": "Identifier",
+              "start": 405,
+              "end": 415,
+              "name": "keyed_list",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXForExpression",
+              "start": 418,
+              "end": 519,
+              "statement": {
+                "type": "ForOfStatement",
+                "start": 419,
+                "end": 519,
+                "left": {
+                  "type": "VariableDeclaration",
+                  "start": 424,
+                  "end": 434,
+                  "kind": "const",
+                  "declarations": [
+                    {
+                      "type": "VariableDeclarator",
+                      "start": 430,
+                      "end": 434,
+                      "id": {
+                        "type": "Identifier",
+                        "start": 430,
+                        "end": 434,
+                        "name": "item",
+                        "decorators": [],
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "init": null,
+                      "definite": false
+                    }
+                  ],
+                  "declare": false
+                },
+                "right": {
+                  "type": "Identifier",
+                  "start": 438,
+                  "end": 443,
+                  "name": "keyed",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 476,
+                  "end": 519,
+                  "body": [
+                    {
+                      "type": "JSXElement",
+                      "start": 482,
+                      "end": 517,
+                      "openingElement": {
+                        "type": "JSXOpeningElement",
+                        "start": 482,
+                        "end": 488,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 483,
+                          "end": 487,
+                          "name": "span"
+                        },
+                        "attributes": [],
+                        "selfClosing": false,
+                        "typeArguments": null
+                      },
+                      "children": [
+                        {
+                          "type": "JSXExpressionContainer",
+                          "start": 488,
+                          "end": 500,
+                          "expression": {
+                            "type": "Identifier",
+                            "start": 489,
+                            "end": 499,
+                            "name": "item_index",
+                            "decorators": [],
+                            "optional": false,
+                            "typeAnnotation": null
+                          }
+                        },
+                        {
+                          "type": "JSXText",
+                          "start": 500,
+                          "end": 501,
+                          "value": ":",
+                          "raw": ":"
+                        },
+                        {
+                          "type": "JSXExpressionContainer",
+                          "start": 501,
+                          "end": 510,
+                          "expression": {
+                            "type": "MemberExpression",
+                            "start": 502,
+                            "end": 509,
+                            "object": {
+                              "type": "Identifier",
+                              "start": 502,
+                              "end": 506,
+                              "name": "item",
+                              "decorators": [],
+                              "optional": false,
+                              "typeAnnotation": null
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 507,
+                              "end": 509,
+                              "name": "id",
+                              "decorators": [],
+                              "optional": false,
+                              "typeAnnotation": null
+                            },
+                            "computed": false,
+                            "optional": false
+                          }
+                        }
+                      ],
+                      "closingElement": {
+                        "type": "JSXClosingElement",
+                        "start": 510,
+                        "end": 517,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 512,
+                          "end": 516,
+                          "name": "span"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "await": false,
+                "index": {
+                  "type": "Identifier",
+                  "start": 451,
+                  "end": 461,
+                  "name": "item_index",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "key": {
+                  "type": "MemberExpression",
+                  "start": 467,
+                  "end": 474,
+                  "object": {
+                    "type": "Identifier",
+                    "start": 467,
+                    "end": 471,
+                    "name": "item",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "property": {
+                    "type": "Identifier",
+                    "start": 472,
+                    "end": 474,
+                    "name": "id",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "computed": false,
+                  "optional": false
+                }
+              },
+              "empty": null
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 522,
+        "end": 610,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 528,
+            "end": 609,
+            "id": {
+              "type": "Identifier",
+              "start": 528,
+              "end": 535,
+              "name": "counted",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXForExpression",
+              "start": 538,
+              "end": 609,
+              "statement": {
+                "type": "ForStatement",
+                "start": 539,
+                "end": 609,
+                "init": {
+                  "type": "VariableDeclaration",
+                  "start": 544,
+                  "end": 553,
+                  "kind": "let",
+                  "declarations": [
+                    {
+                      "type": "VariableDeclarator",
+                      "start": 548,
+                      "end": 553,
+                      "id": {
+                        "type": "Identifier",
+                        "start": 548,
+                        "end": 549,
+                        "name": "i",
+                        "decorators": [],
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "init": {
+                        "type": "Literal",
+                        "start": 552,
+                        "end": 553,
+                        "value": 0,
+                        "raw": "0"
+                      },
+                      "definite": false
+                    }
+                  ],
+                  "declare": false
+                },
+                "test": {
+                  "type": "BinaryExpression",
+                  "start": 555,
+                  "end": 571,
+                  "left": {
+                    "type": "Identifier",
+                    "start": 555,
+                    "end": 556,
+                    "name": "i",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "right": {
+                    "type": "MemberExpression",
+                    "start": 559,
+                    "end": 571,
+                    "object": {
+                      "type": "Identifier",
+                      "start": 559,
+                      "end": 564,
+                      "name": "items",
+                      "decorators": [],
+                      "optional": false,
+                      "typeAnnotation": null
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "start": 565,
+                      "end": 571,
+                      "name": "length",
+                      "decorators": [],
+                      "optional": false,
+                      "typeAnnotation": null
+                    },
+                    "computed": false,
+                    "optional": false
+                  },
+                  "operator": "<"
+                },
+                "update": {
+                  "type": "UpdateExpression",
+                  "start": 573,
+                  "end": 576,
+                  "argument": {
+                    "type": "Identifier",
+                    "start": 573,
+                    "end": 574,
+                    "name": "i",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "operator": "++",
+                  "prefix": false
+                },
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 578,
+                  "end": 609,
+                  "body": [
+                    {
+                      "type": "JSXElement",
+                      "start": 584,
+                      "end": 607,
+                      "openingElement": {
+                        "type": "JSXOpeningElement",
+                        "start": 584,
+                        "end": 590,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 585,
+                          "end": 589,
+                          "name": "span"
+                        },
+                        "attributes": [],
+                        "selfClosing": false,
+                        "typeArguments": null
+                      },
+                      "children": [
+                        {
+                          "type": "JSXExpressionContainer",
+                          "start": 590,
+                          "end": 600,
+                          "expression": {
+                            "type": "MemberExpression",
+                            "start": 591,
+                            "end": 599,
+                            "object": {
+                              "type": "Identifier",
+                              "start": 591,
+                              "end": 596,
+                              "name": "items",
+                              "decorators": [],
+                              "optional": false,
+                              "typeAnnotation": null
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 597,
+                              "end": 598,
+                              "name": "i",
+                              "decorators": [],
+                              "optional": false,
+                              "typeAnnotation": null
+                            },
+                            "computed": true,
+                            "optional": false
+                          }
+                        }
+                      ],
+                      "closingElement": {
+                        "type": "JSXClosingElement",
+                        "start": 600,
+                        "end": 607,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 602,
+                          "end": 606,
+                          "name": "span"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "empty": null
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/control-flow-if.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/control-flow-if.snapshot.json
@@ -1,0 +1,615 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 499,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 29,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 14,
+            "end": 28,
+            "id": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 28,
+              "name": "ready",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 19,
+                "end": 28,
+                "typeAnnotation": {
+                  "type": "TSBooleanKeyword",
+                  "start": 21,
+                  "end": 28
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 30,
+        "end": 62,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 44,
+            "end": 61,
+            "id": {
+              "type": "Identifier",
+              "start": 44,
+              "end": 61,
+              "name": "fallback",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 52,
+                "end": 61,
+                "typeAnnotation": {
+                  "type": "TSBooleanKeyword",
+                  "start": 54,
+                  "end": 61
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 64,
+        "end": 327,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 70,
+            "end": 326,
+            "id": {
+              "type": "Identifier",
+              "start": 70,
+              "end": 75,
+              "name": "child",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 78,
+              "end": 326,
+              "expression": {
+                "type": "JSXElement",
+                "start": 84,
+                "end": 324,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 84,
+                  "end": 93,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 85,
+                    "end": 92,
+                    "name": "section"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 93,
+                    "end": 102,
+                    "value": "\n        ",
+                    "raw": "\n        "
+                  },
+                  {
+                    "type": "JSXIfExpression",
+                    "start": 102,
+                    "end": 309,
+                    "test": {
+                      "type": "Identifier",
+                      "start": 107,
+                      "end": 112,
+                      "name": "ready",
+                      "decorators": [],
+                      "optional": false,
+                      "typeAnnotation": null
+                    },
+                    "consequent": {
+                      "type": "BlockStatement",
+                      "start": 114,
+                      "end": 193,
+                      "body": [
+                        {
+                          "type": "VariableDeclaration",
+                          "start": 128,
+                          "end": 150,
+                          "kind": "const",
+                          "declarations": [
+                            {
+                              "type": "VariableDeclarator",
+                              "start": 134,
+                              "end": 149,
+                              "id": {
+                                "type": "Identifier",
+                                "start": 134,
+                                "end": 139,
+                                "name": "label",
+                                "decorators": [],
+                                "typeAnnotation": null,
+                                "optional": false
+                              },
+                              "init": {
+                                "type": "Literal",
+                                "start": 142,
+                                "end": 149,
+                                "value": "ready",
+                                "raw": "\"ready\""
+                              },
+                              "definite": false
+                            }
+                          ],
+                          "declare": false
+                        },
+                        {
+                          "type": "JSXElement",
+                          "start": 163,
+                          "end": 183,
+                          "openingElement": {
+                            "type": "JSXOpeningElement",
+                            "start": 163,
+                            "end": 169,
+                            "name": {
+                              "type": "JSXIdentifier",
+                              "start": 164,
+                              "end": 168,
+                              "name": "span"
+                            },
+                            "attributes": [],
+                            "selfClosing": false,
+                            "typeArguments": null
+                          },
+                          "children": [
+                            {
+                              "type": "JSXExpressionContainer",
+                              "start": 169,
+                              "end": 176,
+                              "expression": {
+                                "type": "Identifier",
+                                "start": 170,
+                                "end": 175,
+                                "name": "label",
+                                "decorators": [],
+                                "optional": false,
+                                "typeAnnotation": null
+                              }
+                            }
+                          ],
+                          "closingElement": {
+                            "type": "JSXClosingElement",
+                            "start": 176,
+                            "end": 183,
+                            "name": {
+                              "type": "JSXIdentifier",
+                              "start": 178,
+                              "end": 182,
+                              "name": "span"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "alternate": {
+                      "type": "JSXIfExpression",
+                      "start": 200,
+                      "end": 309,
+                      "test": {
+                        "type": "Identifier",
+                        "start": 205,
+                        "end": 213,
+                        "name": "fallback",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      "consequent": {
+                        "type": "BlockStatement",
+                        "start": 215,
+                        "end": 260,
+                        "body": [
+                          {
+                            "type": "JSXElement",
+                            "start": 229,
+                            "end": 250,
+                            "openingElement": {
+                              "type": "JSXOpeningElement",
+                              "start": 229,
+                              "end": 235,
+                              "name": {
+                                "type": "JSXIdentifier",
+                                "start": 230,
+                                "end": 234,
+                                "name": "span"
+                              },
+                              "attributes": [],
+                              "selfClosing": false,
+                              "typeArguments": null
+                            },
+                            "children": [
+                              {
+                                "type": "JSXText",
+                                "start": 235,
+                                "end": 243,
+                                "value": "fallback",
+                                "raw": "fallback"
+                              }
+                            ],
+                            "closingElement": {
+                              "type": "JSXClosingElement",
+                              "start": 243,
+                              "end": 250,
+                              "name": {
+                                "type": "JSXIdentifier",
+                                "start": 245,
+                                "end": 249,
+                                "name": "span"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "alternate": {
+                        "type": "BlockStatement",
+                        "start": 267,
+                        "end": 309,
+                        "body": [
+                          {
+                            "type": "JSXElement",
+                            "start": 281,
+                            "end": 299,
+                            "openingElement": {
+                              "type": "JSXOpeningElement",
+                              "start": 281,
+                              "end": 287,
+                              "name": {
+                                "type": "JSXIdentifier",
+                                "start": 282,
+                                "end": 286,
+                                "name": "span"
+                              },
+                              "attributes": [],
+                              "selfClosing": false,
+                              "typeArguments": null
+                            },
+                            "children": [
+                              {
+                                "type": "JSXText",
+                                "start": 287,
+                                "end": 292,
+                                "value": "empty",
+                                "raw": "empty"
+                              }
+                            ],
+                            "closingElement": {
+                              "type": "JSXClosingElement",
+                              "start": 292,
+                              "end": 299,
+                              "name": {
+                                "type": "JSXIdentifier",
+                                "start": 294,
+                                "end": 298,
+                                "name": "span"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 309,
+                    "end": 314,
+                    "value": "\n    ",
+                    "raw": "\n    "
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 314,
+                  "end": 324,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 316,
+                    "end": 323,
+                    "name": "section"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 329,
+        "end": 410,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 335,
+            "end": 409,
+            "id": {
+              "type": "Identifier",
+              "start": 335,
+              "end": 340,
+              "name": "value",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXIfExpression",
+              "start": 343,
+              "end": 409,
+              "test": {
+                "type": "Identifier",
+                "start": 348,
+                "end": 353,
+                "name": "ready",
+                "decorators": [],
+                "optional": false,
+                "typeAnnotation": null
+              },
+              "consequent": {
+                "type": "BlockStatement",
+                "start": 355,
+                "end": 379,
+                "body": [
+                  {
+                    "type": "JSXElement",
+                    "start": 361,
+                    "end": 377,
+                    "openingElement": {
+                      "type": "JSXOpeningElement",
+                      "start": 361,
+                      "end": 367,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 362,
+                        "end": 366,
+                        "name": "span"
+                      },
+                      "attributes": [],
+                      "selfClosing": false,
+                      "typeArguments": null
+                    },
+                    "children": [
+                      {
+                        "type": "JSXText",
+                        "start": 367,
+                        "end": 370,
+                        "value": "yes",
+                        "raw": "yes"
+                      }
+                    ],
+                    "closingElement": {
+                      "type": "JSXClosingElement",
+                      "start": 370,
+                      "end": 377,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 372,
+                        "end": 376,
+                        "name": "span"
+                      }
+                    }
+                  }
+                ]
+              },
+              "alternate": {
+                "type": "BlockStatement",
+                "start": 386,
+                "end": 409,
+                "body": [
+                  {
+                    "type": "JSXElement",
+                    "start": 392,
+                    "end": 407,
+                    "openingElement": {
+                      "type": "JSXOpeningElement",
+                      "start": 392,
+                      "end": 398,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 393,
+                        "end": 397,
+                        "name": "span"
+                      },
+                      "attributes": [],
+                      "selfClosing": false,
+                      "typeArguments": null
+                    },
+                    "children": [
+                      {
+                        "type": "JSXText",
+                        "start": 398,
+                        "end": 400,
+                        "value": "no",
+                        "raw": "no"
+                      }
+                    ],
+                    "closingElement": {
+                      "type": "JSXClosingElement",
+                      "start": 400,
+                      "end": 407,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 402,
+                        "end": 406,
+                        "name": "span"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 412,
+        "end": 498,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 418,
+            "end": 497,
+            "id": {
+              "type": "Identifier",
+              "start": 418,
+              "end": 423,
+              "name": "block",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXCodeBlock",
+              "start": 426,
+              "end": 497,
+              "body": [
+                {
+                  "type": "VariableDeclaration",
+                  "start": 433,
+                  "end": 450,
+                  "kind": "const",
+                  "declarations": [
+                    {
+                      "type": "VariableDeclarator",
+                      "start": 439,
+                      "end": 449,
+                      "id": {
+                        "type": "Identifier",
+                        "start": 439,
+                        "end": 441,
+                        "name": "ok",
+                        "decorators": [],
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "init": {
+                        "type": "Identifier",
+                        "start": 444,
+                        "end": 449,
+                        "name": "ready",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      "definite": false
+                    }
+                  ],
+                  "declare": false
+                }
+              ],
+              "render": {
+                "type": "JSXIfExpression",
+                "start": 455,
+                "end": 495,
+                "test": {
+                  "type": "Identifier",
+                  "start": 460,
+                  "end": 462,
+                  "name": "ok",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "consequent": {
+                  "type": "BlockStatement",
+                  "start": 464,
+                  "end": 495,
+                  "body": [
+                    {
+                      "type": "JSXElement",
+                      "start": 474,
+                      "end": 489,
+                      "openingElement": {
+                        "type": "JSXOpeningElement",
+                        "start": 474,
+                        "end": 480,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 475,
+                          "end": 479,
+                          "name": "span"
+                        },
+                        "attributes": [],
+                        "selfClosing": false,
+                        "typeArguments": null
+                      },
+                      "children": [
+                        {
+                          "type": "JSXText",
+                          "start": 480,
+                          "end": 482,
+                          "value": "ok",
+                          "raw": "ok"
+                        }
+                      ],
+                      "closingElement": {
+                        "type": "JSXClosingElement",
+                        "start": 482,
+                        "end": 489,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 484,
+                          "end": 488,
+                          "name": "span"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "alternate": null
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/control-flow-switch.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/control-flow-switch.snapshot.json
@@ -1,0 +1,517 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 549,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 50,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 14,
+            "end": 49,
+            "id": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 49,
+              "name": "status",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 20,
+                "end": 49,
+                "typeAnnotation": {
+                  "type": "TSUnionType",
+                  "start": 22,
+                  "end": 49,
+                  "types": [
+                    {
+                      "type": "TSLiteralType",
+                      "start": 22,
+                      "end": 29,
+                      "literal": {
+                        "type": "Literal",
+                        "start": 22,
+                        "end": 29,
+                        "value": "ready",
+                        "raw": "\"ready\""
+                      }
+                    },
+                    {
+                      "type": "TSLiteralType",
+                      "start": 32,
+                      "end": 39,
+                      "literal": {
+                        "type": "Literal",
+                        "start": 32,
+                        "end": 39,
+                        "value": "empty",
+                        "raw": "\"empty\""
+                      }
+                    },
+                    {
+                      "type": "TSLiteralType",
+                      "start": 42,
+                      "end": 49,
+                      "literal": {
+                        "type": "Literal",
+                        "start": 42,
+                        "end": 49,
+                        "value": "error",
+                        "raw": "\"error\""
+                      }
+                    }
+                  ]
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 52,
+        "end": 405,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 58,
+            "end": 404,
+            "id": {
+              "type": "Identifier",
+              "start": 58,
+              "end": 62,
+              "name": "view",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 65,
+              "end": 404,
+              "expression": {
+                "type": "JSXElement",
+                "start": 71,
+                "end": 402,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 71,
+                  "end": 80,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 72,
+                    "end": 79,
+                    "name": "section"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 80,
+                    "end": 89,
+                    "value": "\n        ",
+                    "raw": "\n        "
+                  },
+                  {
+                    "type": "JSXSwitchExpression",
+                    "start": 89,
+                    "end": 387,
+                    "statement": {
+                      "type": "SwitchStatement",
+                      "start": 90,
+                      "end": 387,
+                      "discriminant": {
+                        "type": "Identifier",
+                        "start": 98,
+                        "end": 104,
+                        "name": "status",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      "cases": [
+                        {
+                          "type": "SwitchCase",
+                          "start": 120,
+                          "end": 185,
+                          "test": {
+                            "type": "Literal",
+                            "start": 126,
+                            "end": 133,
+                            "value": "ready",
+                            "raw": "\"ready\""
+                          },
+                          "consequent": [
+                            {
+                              "type": "JSXElement",
+                              "start": 153,
+                              "end": 171,
+                              "openingElement": {
+                                "type": "JSXOpeningElement",
+                                "start": 153,
+                                "end": 159,
+                                "name": {
+                                  "type": "JSXIdentifier",
+                                  "start": 154,
+                                  "end": 158,
+                                  "name": "span"
+                                },
+                                "attributes": [],
+                                "selfClosing": false,
+                                "typeArguments": null
+                              },
+                              "children": [
+                                {
+                                  "type": "JSXText",
+                                  "start": 159,
+                                  "end": 164,
+                                  "value": "ready",
+                                  "raw": "ready"
+                                }
+                              ],
+                              "closingElement": {
+                                "type": "JSXClosingElement",
+                                "start": 164,
+                                "end": 171,
+                                "name": {
+                                  "type": "JSXIdentifier",
+                                  "start": 166,
+                                  "end": 170,
+                                  "name": "span"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SwitchCase",
+                          "start": 198,
+                          "end": 304,
+                          "test": {
+                            "type": "Literal",
+                            "start": 204,
+                            "end": 211,
+                            "value": "empty",
+                            "raw": "\"empty\""
+                          },
+                          "consequent": [
+                            {
+                              "type": "VariableDeclaration",
+                              "start": 231,
+                              "end": 253,
+                              "kind": "const",
+                              "declarations": [
+                                {
+                                  "type": "VariableDeclarator",
+                                  "start": 237,
+                                  "end": 252,
+                                  "id": {
+                                    "type": "Identifier",
+                                    "start": 237,
+                                    "end": 242,
+                                    "name": "label",
+                                    "decorators": [],
+                                    "typeAnnotation": null,
+                                    "optional": false
+                                  },
+                                  "init": {
+                                    "type": "Literal",
+                                    "start": 245,
+                                    "end": 252,
+                                    "value": "empty",
+                                    "raw": "\"empty\""
+                                  },
+                                  "definite": false
+                                }
+                              ],
+                              "declare": false
+                            },
+                            {
+                              "type": "JSXElement",
+                              "start": 270,
+                              "end": 290,
+                              "openingElement": {
+                                "type": "JSXOpeningElement",
+                                "start": 270,
+                                "end": 276,
+                                "name": {
+                                  "type": "JSXIdentifier",
+                                  "start": 271,
+                                  "end": 275,
+                                  "name": "span"
+                                },
+                                "attributes": [],
+                                "selfClosing": false,
+                                "typeArguments": null
+                              },
+                              "children": [
+                                {
+                                  "type": "JSXExpressionContainer",
+                                  "start": 276,
+                                  "end": 283,
+                                  "expression": {
+                                    "type": "Identifier",
+                                    "start": 277,
+                                    "end": 282,
+                                    "name": "label",
+                                    "decorators": [],
+                                    "optional": false,
+                                    "typeAnnotation": null
+                                  }
+                                }
+                              ],
+                              "closingElement": {
+                                "type": "JSXClosingElement",
+                                "start": 283,
+                                "end": 290,
+                                "name": {
+                                  "type": "JSXIdentifier",
+                                  "start": 285,
+                                  "end": 289,
+                                  "name": "span"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SwitchCase",
+                          "start": 317,
+                          "end": 377,
+                          "test": null,
+                          "consequent": [
+                            {
+                              "type": "JSXElement",
+                              "start": 345,
+                              "end": 363,
+                              "openingElement": {
+                                "type": "JSXOpeningElement",
+                                "start": 345,
+                                "end": 351,
+                                "name": {
+                                  "type": "JSXIdentifier",
+                                  "start": 346,
+                                  "end": 350,
+                                  "name": "span"
+                                },
+                                "attributes": [],
+                                "selfClosing": false,
+                                "typeArguments": null
+                              },
+                              "children": [
+                                {
+                                  "type": "JSXText",
+                                  "start": 351,
+                                  "end": 356,
+                                  "value": "error",
+                                  "raw": "error"
+                                }
+                              ],
+                              "closingElement": {
+                                "type": "JSXClosingElement",
+                                "start": 356,
+                                "end": 363,
+                                "name": {
+                                  "type": "JSXIdentifier",
+                                  "start": 358,
+                                  "end": 362,
+                                  "name": "span"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 387,
+                    "end": 392,
+                    "value": "\n    ",
+                    "raw": "\n    "
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 392,
+                  "end": 402,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 394,
+                    "end": 401,
+                    "name": "section"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 407,
+        "end": 548,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 413,
+            "end": 547,
+            "id": {
+              "type": "Identifier",
+              "start": 413,
+              "end": 418,
+              "name": "value",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXSwitchExpression",
+              "start": 421,
+              "end": 547,
+              "statement": {
+                "type": "SwitchStatement",
+                "start": 422,
+                "end": 547,
+                "discriminant": {
+                  "type": "Identifier",
+                  "start": 430,
+                  "end": 436,
+                  "name": "status",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "cases": [
+                  {
+                    "type": "SwitchCase",
+                    "start": 444,
+                    "end": 493,
+                    "test": {
+                      "type": "Literal",
+                      "start": 450,
+                      "end": 457,
+                      "value": "ready",
+                      "raw": "\"ready\""
+                    },
+                    "consequent": [
+                      {
+                        "type": "JSXElement",
+                        "start": 469,
+                        "end": 487,
+                        "openingElement": {
+                          "type": "JSXOpeningElement",
+                          "start": 469,
+                          "end": 475,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 470,
+                            "end": 474,
+                            "name": "span"
+                          },
+                          "attributes": [],
+                          "selfClosing": false,
+                          "typeArguments": null
+                        },
+                        "children": [
+                          {
+                            "type": "JSXText",
+                            "start": 475,
+                            "end": 480,
+                            "value": "ready",
+                            "raw": "ready"
+                          }
+                        ],
+                        "closingElement": {
+                          "type": "JSXClosingElement",
+                          "start": 480,
+                          "end": 487,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 482,
+                            "end": 486,
+                            "name": "span"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SwitchCase",
+                    "start": 498,
+                    "end": 545,
+                    "test": null,
+                    "consequent": [
+                      {
+                        "type": "JSXElement",
+                        "start": 518,
+                        "end": 539,
+                        "openingElement": {
+                          "type": "JSXOpeningElement",
+                          "start": 518,
+                          "end": 524,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 519,
+                            "end": 523,
+                            "name": "span"
+                          },
+                          "attributes": [],
+                          "selfClosing": false,
+                          "typeArguments": null
+                        },
+                        "children": [
+                          {
+                            "type": "JSXText",
+                            "start": 524,
+                            "end": 532,
+                            "value": "fallback",
+                            "raw": "fallback"
+                          }
+                        ],
+                        "closingElement": {
+                          "type": "JSXClosingElement",
+                          "start": 532,
+                          "end": 539,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 534,
+                            "end": 538,
+                            "name": "span"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/control-flow-try.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/control-flow-try.snapshot.json
@@ -1,0 +1,684 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 528,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 29,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 14,
+            "end": 28,
+            "id": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 28,
+              "name": "ready",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 19,
+                "end": 28,
+                "typeAnnotation": {
+                  "type": "TSBooleanKeyword",
+                  "start": 21,
+                  "end": 28
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 31,
+        "end": 346,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 37,
+            "end": 345,
+            "id": {
+              "type": "Identifier",
+              "start": 37,
+              "end": 41,
+              "name": "view",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 44,
+              "end": 345,
+              "expression": {
+                "type": "JSXElement",
+                "start": 50,
+                "end": 343,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 50,
+                  "end": 59,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 51,
+                    "end": 58,
+                    "name": "section"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 59,
+                    "end": 68,
+                    "value": "\n        ",
+                    "raw": "\n        "
+                  },
+                  {
+                    "type": "JSXTryExpression",
+                    "start": 68,
+                    "end": 328,
+                    "statement": {
+                      "type": "TryStatement",
+                      "start": 69,
+                      "end": 328,
+                      "block": {
+                        "type": "BlockStatement",
+                        "start": 73,
+                        "end": 172,
+                        "body": [
+                          {
+                            "type": "VariableDeclaration",
+                            "start": 87,
+                            "end": 129,
+                            "kind": "const",
+                            "declarations": [
+                              {
+                                "type": "VariableDeclarator",
+                                "start": 93,
+                                "end": 128,
+                                "id": {
+                                  "type": "Identifier",
+                                  "start": 93,
+                                  "end": 98,
+                                  "name": "label",
+                                  "decorators": [],
+                                  "typeAnnotation": null,
+                                  "optional": false
+                                },
+                                "init": {
+                                  "type": "ConditionalExpression",
+                                  "start": 101,
+                                  "end": 128,
+                                  "test": {
+                                    "type": "Identifier",
+                                    "start": 101,
+                                    "end": 106,
+                                    "name": "ready",
+                                    "decorators": [],
+                                    "optional": false,
+                                    "typeAnnotation": null
+                                  },
+                                  "consequent": {
+                                    "type": "Literal",
+                                    "start": 109,
+                                    "end": 116,
+                                    "value": "ready",
+                                    "raw": "\"ready\""
+                                  },
+                                  "alternate": {
+                                    "type": "Literal",
+                                    "start": 119,
+                                    "end": 128,
+                                    "value": "waiting",
+                                    "raw": "\"waiting\""
+                                  }
+                                },
+                                "definite": false
+                              }
+                            ],
+                            "declare": false
+                          },
+                          {
+                            "type": "JSXElement",
+                            "start": 142,
+                            "end": 162,
+                            "openingElement": {
+                              "type": "JSXOpeningElement",
+                              "start": 142,
+                              "end": 148,
+                              "name": {
+                                "type": "JSXIdentifier",
+                                "start": 143,
+                                "end": 147,
+                                "name": "span"
+                              },
+                              "attributes": [],
+                              "selfClosing": false,
+                              "typeArguments": null
+                            },
+                            "children": [
+                              {
+                                "type": "JSXExpressionContainer",
+                                "start": 148,
+                                "end": 155,
+                                "expression": {
+                                  "type": "Identifier",
+                                  "start": 149,
+                                  "end": 154,
+                                  "name": "label",
+                                  "decorators": [],
+                                  "optional": false,
+                                  "typeAnnotation": null
+                                }
+                              }
+                            ],
+                            "closingElement": {
+                              "type": "JSXClosingElement",
+                              "start": 155,
+                              "end": 162,
+                              "name": {
+                                "type": "JSXIdentifier",
+                                "start": 157,
+                                "end": 161,
+                                "name": "span"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "handler": {
+                        "type": "CatchClause",
+                        "start": 227,
+                        "end": 328,
+                        "param": {
+                          "type": "Identifier",
+                          "start": 235,
+                          "end": 247,
+                          "name": "error",
+                          "decorators": [],
+                          "typeAnnotation": {
+                            "type": "TSTypeAnnotation",
+                            "start": 240,
+                            "end": 247,
+                            "typeAnnotation": {
+                              "type": "TSTypeReference",
+                              "start": 242,
+                              "end": 247,
+                              "typeName": {
+                                "type": "Identifier",
+                                "start": 242,
+                                "end": 247,
+                                "name": "Error",
+                                "decorators": [],
+                                "optional": false,
+                                "typeAnnotation": null
+                              },
+                              "typeArguments": null
+                            }
+                          },
+                          "optional": false
+                        },
+                        "resetParam": {
+                          "type": "Identifier",
+                          "start": 249,
+                          "end": 254,
+                          "name": "reset",
+                          "decorators": [],
+                          "typeAnnotation": null,
+                          "optional": false
+                        },
+                        "body": {
+                          "type": "BlockStatement",
+                          "start": 256,
+                          "end": 328,
+                          "body": [
+                            {
+                              "type": "JSXElement",
+                              "start": 270,
+                              "end": 318,
+                              "openingElement": {
+                                "type": "JSXOpeningElement",
+                                "start": 270,
+                                "end": 294,
+                                "name": {
+                                  "type": "JSXIdentifier",
+                                  "start": 271,
+                                  "end": 277,
+                                  "name": "button"
+                                },
+                                "attributes": [
+                                  {
+                                    "type": "JSXAttribute",
+                                    "start": 278,
+                                    "end": 293,
+                                    "name": {
+                                      "type": "JSXIdentifier",
+                                      "start": 278,
+                                      "end": 285,
+                                      "name": "onClick"
+                                    },
+                                    "value": {
+                                      "type": "JSXExpressionContainer",
+                                      "start": 286,
+                                      "end": 293,
+                                      "expression": {
+                                        "type": "Identifier",
+                                        "start": 287,
+                                        "end": 292,
+                                        "name": "reset",
+                                        "decorators": [],
+                                        "optional": false,
+                                        "typeAnnotation": null
+                                      }
+                                    }
+                                  }
+                                ],
+                                "selfClosing": false,
+                                "typeArguments": null
+                              },
+                              "children": [
+                                {
+                                  "type": "JSXExpressionContainer",
+                                  "start": 294,
+                                  "end": 309,
+                                  "expression": {
+                                    "type": "MemberExpression",
+                                    "start": 295,
+                                    "end": 308,
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 295,
+                                      "end": 300,
+                                      "name": "error",
+                                      "decorators": [],
+                                      "optional": false,
+                                      "typeAnnotation": null
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 301,
+                                      "end": 308,
+                                      "name": "message",
+                                      "decorators": [],
+                                      "optional": false,
+                                      "typeAnnotation": null
+                                    },
+                                    "computed": false,
+                                    "optional": false
+                                  }
+                                }
+                              ],
+                              "closingElement": {
+                                "type": "JSXClosingElement",
+                                "start": 309,
+                                "end": 318,
+                                "name": {
+                                  "type": "JSXIdentifier",
+                                  "start": 311,
+                                  "end": 317,
+                                  "name": "button"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "finalizer": null
+                    },
+                    "pending": {
+                      "type": "BlockStatement",
+                      "start": 182,
+                      "end": 226,
+                      "body": [
+                        {
+                          "type": "JSXElement",
+                          "start": 196,
+                          "end": 216,
+                          "openingElement": {
+                            "type": "JSXOpeningElement",
+                            "start": 196,
+                            "end": 202,
+                            "name": {
+                              "type": "JSXIdentifier",
+                              "start": 197,
+                              "end": 201,
+                              "name": "span"
+                            },
+                            "attributes": [],
+                            "selfClosing": false,
+                            "typeArguments": null
+                          },
+                          "children": [
+                            {
+                              "type": "JSXText",
+                              "start": 202,
+                              "end": 209,
+                              "value": "pending",
+                              "raw": "pending"
+                            }
+                          ],
+                          "closingElement": {
+                            "type": "JSXClosingElement",
+                            "start": 209,
+                            "end": 216,
+                            "name": {
+                              "type": "JSXIdentifier",
+                              "start": 211,
+                              "end": 215,
+                              "name": "span"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 328,
+                    "end": 333,
+                    "value": "\n    ",
+                    "raw": "\n    "
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 333,
+                  "end": 343,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 335,
+                    "end": 342,
+                    "name": "section"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 348,
+        "end": 439,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 354,
+            "end": 438,
+            "id": {
+              "type": "Identifier",
+              "start": 354,
+              "end": 366,
+              "name": "pending_only",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXTryExpression",
+              "start": 369,
+              "end": 438,
+              "statement": {
+                "type": "TryStatement",
+                "start": 370,
+                "end": 438,
+                "block": {
+                  "type": "BlockStatement",
+                  "start": 374,
+                  "end": 400,
+                  "body": [
+                    {
+                      "type": "JSXElement",
+                      "start": 380,
+                      "end": 398,
+                      "openingElement": {
+                        "type": "JSXOpeningElement",
+                        "start": 380,
+                        "end": 386,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 381,
+                          "end": 385,
+                          "name": "span"
+                        },
+                        "attributes": [],
+                        "selfClosing": false,
+                        "typeArguments": null
+                      },
+                      "children": [
+                        {
+                          "type": "JSXText",
+                          "start": 386,
+                          "end": 391,
+                          "value": "ready",
+                          "raw": "ready"
+                        }
+                      ],
+                      "closingElement": {
+                        "type": "JSXClosingElement",
+                        "start": 391,
+                        "end": 398,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 393,
+                          "end": 397,
+                          "name": "span"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "handler": null,
+                "finalizer": null
+              },
+              "pending": {
+                "type": "BlockStatement",
+                "start": 410,
+                "end": 438,
+                "body": [
+                  {
+                    "type": "JSXElement",
+                    "start": 416,
+                    "end": 436,
+                    "openingElement": {
+                      "type": "JSXOpeningElement",
+                      "start": 416,
+                      "end": 422,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 417,
+                        "end": 421,
+                        "name": "span"
+                      },
+                      "attributes": [],
+                      "selfClosing": false,
+                      "typeArguments": null
+                    },
+                    "children": [
+                      {
+                        "type": "JSXText",
+                        "start": 422,
+                        "end": 429,
+                        "value": "pending",
+                        "raw": "pending"
+                      }
+                    ],
+                    "closingElement": {
+                      "type": "JSXClosingElement",
+                      "start": 429,
+                      "end": 436,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 431,
+                        "end": 435,
+                        "name": "span"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 441,
+        "end": 527,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 447,
+            "end": 526,
+            "id": {
+              "type": "Identifier",
+              "start": 447,
+              "end": 457,
+              "name": "catch_only",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXTryExpression",
+              "start": 460,
+              "end": 526,
+              "statement": {
+                "type": "TryStatement",
+                "start": 461,
+                "end": 526,
+                "block": {
+                  "type": "BlockStatement",
+                  "start": 465,
+                  "end": 491,
+                  "body": [
+                    {
+                      "type": "JSXElement",
+                      "start": 471,
+                      "end": 489,
+                      "openingElement": {
+                        "type": "JSXOpeningElement",
+                        "start": 471,
+                        "end": 477,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 472,
+                          "end": 476,
+                          "name": "span"
+                        },
+                        "attributes": [],
+                        "selfClosing": false,
+                        "typeArguments": null
+                      },
+                      "children": [
+                        {
+                          "type": "JSXText",
+                          "start": 477,
+                          "end": 482,
+                          "value": "ready",
+                          "raw": "ready"
+                        }
+                      ],
+                      "closingElement": {
+                        "type": "JSXClosingElement",
+                        "start": 482,
+                        "end": 489,
+                        "name": {
+                          "type": "JSXIdentifier",
+                          "start": 484,
+                          "end": 488,
+                          "name": "span"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "handler": {
+                  "type": "CatchClause",
+                  "start": 492,
+                  "end": 526,
+                  "param": null,
+                  "resetParam": null,
+                  "body": {
+                    "type": "BlockStatement",
+                    "start": 499,
+                    "end": 526,
+                    "body": [
+                      {
+                        "type": "JSXElement",
+                        "start": 505,
+                        "end": 524,
+                        "openingElement": {
+                          "type": "JSXOpeningElement",
+                          "start": 505,
+                          "end": 511,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 506,
+                            "end": 510,
+                            "name": "span"
+                          },
+                          "attributes": [],
+                          "selfClosing": false,
+                          "typeArguments": null
+                        },
+                        "children": [
+                          {
+                            "type": "JSXText",
+                            "start": 511,
+                            "end": 517,
+                            "value": "failed",
+                            "raw": "failed"
+                          }
+                        ],
+                        "closingElement": {
+                          "type": "JSXClosingElement",
+                          "start": 517,
+                          "end": 524,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 519,
+                            "end": 523,
+                            "name": "span"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "finalizer": null
+              },
+              "pending": null
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/dynamic-tag.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/dynamic-tag.snapshot.json
@@ -1,0 +1,765 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 361,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start": 0,
+        "end": 33,
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 8,
+          "name": "Tag",
+          "decorators": [],
+          "typeAnnotation": null,
+          "optional": false
+        },
+        "typeParameters": null,
+        "typeAnnotation": {
+          "type": "TSUnionType",
+          "start": 11,
+          "end": 32,
+          "types": [
+            {
+              "type": "TSLiteralType",
+              "start": 11,
+              "end": 20,
+              "literal": {
+                "type": "Literal",
+                "start": 11,
+                "end": 20,
+                "value": "section",
+                "raw": "\"section\""
+              }
+            },
+            {
+              "type": "TSLiteralType",
+              "start": 23,
+              "end": 32,
+              "literal": {
+                "type": "Literal",
+                "start": 23,
+                "end": 32,
+                "value": "article",
+                "raw": "\"article\""
+              }
+            }
+          ]
+        },
+        "declare": false
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 35,
+        "end": 201,
+        "declaration": {
+          "type": "FunctionDeclaration",
+          "start": 42,
+          "end": 201,
+          "id": {
+            "type": "Identifier",
+            "start": 51,
+            "end": 56,
+            "name": "Panel",
+            "decorators": [],
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "generator": false,
+          "async": false,
+          "params": [
+            {
+              "type": "ObjectPattern",
+              "start": 57,
+              "end": 98,
+              "properties": [
+                {
+                  "type": "Property",
+                  "start": 59,
+                  "end": 61,
+                  "kind": "init",
+                  "key": {
+                    "type": "Identifier",
+                    "start": 59,
+                    "end": 61,
+                    "name": "as",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 59,
+                    "end": 61,
+                    "name": "as",
+                    "decorators": [],
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "optional": false
+                },
+                {
+                  "type": "Property",
+                  "start": 63,
+                  "end": 68,
+                  "kind": "init",
+                  "key": {
+                    "type": "Identifier",
+                    "start": 63,
+                    "end": 68,
+                    "name": "title",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 63,
+                    "end": 68,
+                    "name": "title",
+                    "decorators": [],
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "optional": false
+                }
+              ],
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 70,
+                "end": 98,
+                "typeAnnotation": {
+                  "type": "TSTypeLiteral",
+                  "start": 72,
+                  "end": 98,
+                  "members": [
+                    {
+                      "type": "TSPropertySignature",
+                      "start": 74,
+                      "end": 82,
+                      "key": {
+                        "type": "Identifier",
+                        "start": 74,
+                        "end": 76,
+                        "name": "as",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      "typeAnnotation": {
+                        "type": "TSTypeAnnotation",
+                        "start": 76,
+                        "end": 81,
+                        "typeAnnotation": {
+                          "type": "TSTypeReference",
+                          "start": 78,
+                          "end": 81,
+                          "typeName": {
+                            "type": "Identifier",
+                            "start": 78,
+                            "end": 81,
+                            "name": "Tag",
+                            "decorators": [],
+                            "optional": false,
+                            "typeAnnotation": null
+                          },
+                          "typeArguments": null
+                        }
+                      },
+                      "computed": false,
+                      "optional": false,
+                      "readonly": false,
+                      "accessibility": null,
+                      "static": false
+                    },
+                    {
+                      "type": "TSPropertySignature",
+                      "start": 83,
+                      "end": 96,
+                      "key": {
+                        "type": "Identifier",
+                        "start": 83,
+                        "end": 88,
+                        "name": "title",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      "typeAnnotation": {
+                        "type": "TSTypeAnnotation",
+                        "start": 88,
+                        "end": 96,
+                        "typeAnnotation": {
+                          "type": "TSStringKeyword",
+                          "start": 90,
+                          "end": 96
+                        }
+                      },
+                      "computed": false,
+                      "optional": false,
+                      "readonly": false,
+                      "accessibility": null,
+                      "static": false
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start": 100,
+            "end": 201,
+            "body": [
+              {
+                "type": "ReturnStatement",
+                "start": 106,
+                "end": 199,
+                "argument": {
+                  "type": "ParenthesizedExpression",
+                  "start": 113,
+                  "end": 198,
+                  "expression": {
+                    "type": "JSXElement",
+                    "start": 123,
+                    "end": 192,
+                    "openingElement": {
+                      "type": "JSXOpeningElement",
+                      "start": 123,
+                      "end": 147,
+                      "name": {
+                        "type": "JSXExpressionContainer",
+                        "start": 124,
+                        "end": 128,
+                        "expression": {
+                          "type": "Identifier",
+                          "start": 125,
+                          "end": 127,
+                          "name": "as",
+                          "decorators": [],
+                          "optional": false,
+                          "typeAnnotation": null
+                        }
+                      },
+                      "attributes": [
+                        {
+                          "type": "JSXAttribute",
+                          "start": 129,
+                          "end": 146,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 129,
+                            "end": 138,
+                            "name": "className"
+                          },
+                          "value": {
+                            "type": "Literal",
+                            "start": 139,
+                            "end": 146,
+                            "value": "panel",
+                            "raw": "\"panel\""
+                          }
+                        }
+                      ],
+                      "selfClosing": false,
+                      "typeArguments": null
+                    },
+                    "children": [
+                      {
+                        "type": "JSXText",
+                        "start": 147,
+                        "end": 160,
+                        "value": "\n            ",
+                        "raw": "\n            "
+                      },
+                      {
+                        "type": "JSXElement",
+                        "start": 160,
+                        "end": 176,
+                        "openingElement": {
+                          "type": "JSXOpeningElement",
+                          "start": 160,
+                          "end": 164,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 161,
+                            "end": 163,
+                            "name": "h2"
+                          },
+                          "attributes": [],
+                          "selfClosing": false,
+                          "typeArguments": null
+                        },
+                        "children": [
+                          {
+                            "type": "JSXExpressionContainer",
+                            "start": 164,
+                            "end": 171,
+                            "expression": {
+                              "type": "Identifier",
+                              "start": 165,
+                              "end": 170,
+                              "name": "title",
+                              "decorators": [],
+                              "optional": false,
+                              "typeAnnotation": null
+                            }
+                          }
+                        ],
+                        "closingElement": {
+                          "type": "JSXClosingElement",
+                          "start": 171,
+                          "end": 176,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 173,
+                            "end": 175,
+                            "name": "h2"
+                          }
+                        }
+                      },
+                      {
+                        "type": "JSXText",
+                        "start": 176,
+                        "end": 185,
+                        "value": "\n        ",
+                        "raw": "\n        "
+                      }
+                    ],
+                    "closingElement": {
+                      "type": "JSXClosingElement",
+                      "start": 185,
+                      "end": 192,
+                      "name": {
+                        "type": "JSXExpressionContainer",
+                        "start": 187,
+                        "end": 191,
+                        "expression": {
+                          "type": "Identifier",
+                          "start": 188,
+                          "end": 190,
+                          "name": "as",
+                          "decorators": [],
+                          "optional": false,
+                          "typeAnnotation": null
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expression": false,
+          "typeParameters": null,
+          "returnType": null,
+          "declare": false
+        },
+        "specifiers": [],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 203,
+        "end": 257,
+        "declaration": {
+          "type": "VariableDeclaration",
+          "start": 210,
+          "end": 257,
+          "kind": "const",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "start": 216,
+              "end": 256,
+              "id": {
+                "type": "Identifier",
+                "start": 216,
+                "end": 220,
+                "name": "Icon",
+                "decorators": [],
+                "typeAnnotation": null,
+                "optional": false
+              },
+              "init": {
+                "type": "ArrowFunctionExpression",
+                "start": 223,
+                "end": 256,
+                "id": null,
+                "generator": false,
+                "async": false,
+                "params": [
+                  {
+                    "type": "ObjectPattern",
+                    "start": 224,
+                    "end": 243,
+                    "properties": [
+                      {
+                        "type": "Property",
+                        "start": 226,
+                        "end": 228,
+                        "kind": "init",
+                        "key": {
+                          "type": "Identifier",
+                          "start": 226,
+                          "end": 228,
+                          "name": "as",
+                          "decorators": [],
+                          "optional": false,
+                          "typeAnnotation": null
+                        },
+                        "value": {
+                          "type": "Identifier",
+                          "start": 226,
+                          "end": 228,
+                          "name": "as",
+                          "decorators": [],
+                          "typeAnnotation": null,
+                          "optional": false
+                        },
+                        "method": false,
+                        "shorthand": true,
+                        "computed": false,
+                        "optional": false
+                      }
+                    ],
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start": 230,
+                      "end": 243,
+                      "typeAnnotation": {
+                        "type": "TSTypeLiteral",
+                        "start": 232,
+                        "end": 243,
+                        "members": [
+                          {
+                            "type": "TSPropertySignature",
+                            "start": 234,
+                            "end": 241,
+                            "key": {
+                              "type": "Identifier",
+                              "start": 234,
+                              "end": 236,
+                              "name": "as",
+                              "decorators": [],
+                              "optional": false,
+                              "typeAnnotation": null
+                            },
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "start": 236,
+                              "end": 241,
+                              "typeAnnotation": {
+                                "type": "TSTypeReference",
+                                "start": 238,
+                                "end": 241,
+                                "typeName": {
+                                  "type": "Identifier",
+                                  "start": 238,
+                                  "end": 241,
+                                  "name": "Tag",
+                                  "decorators": [],
+                                  "optional": false,
+                                  "typeAnnotation": null
+                                },
+                                "typeArguments": null
+                              }
+                            },
+                            "computed": false,
+                            "optional": false,
+                            "readonly": false,
+                            "accessibility": null,
+                            "static": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "body": {
+                  "type": "JSXElement",
+                  "start": 248,
+                  "end": 256,
+                  "openingElement": {
+                    "type": "JSXOpeningElement",
+                    "start": 248,
+                    "end": 256,
+                    "name": {
+                      "type": "JSXExpressionContainer",
+                      "start": 249,
+                      "end": 253,
+                      "expression": {
+                        "type": "Identifier",
+                        "start": 250,
+                        "end": 252,
+                        "name": "as",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      }
+                    },
+                    "attributes": [],
+                    "selfClosing": true,
+                    "typeArguments": null
+                  },
+                  "children": [],
+                  "closingElement": null
+                },
+                "expression": true,
+                "typeParameters": null,
+                "returnType": null
+              },
+              "definite": false
+            }
+          ],
+          "declare": false
+        },
+        "specifiers": [],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 259,
+        "end": 360,
+        "declaration": {
+          "type": "VariableDeclaration",
+          "start": 266,
+          "end": 360,
+          "kind": "const",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "start": 272,
+              "end": 359,
+              "id": {
+                "type": "Identifier",
+                "start": 272,
+                "end": 286,
+                "name": "WithWhitespace",
+                "decorators": [],
+                "typeAnnotation": null,
+                "optional": false
+              },
+              "init": {
+                "type": "ArrowFunctionExpression",
+                "start": 289,
+                "end": 359,
+                "id": null,
+                "generator": false,
+                "async": false,
+                "params": [
+                  {
+                    "type": "ObjectPattern",
+                    "start": 290,
+                    "end": 309,
+                    "properties": [
+                      {
+                        "type": "Property",
+                        "start": 292,
+                        "end": 294,
+                        "kind": "init",
+                        "key": {
+                          "type": "Identifier",
+                          "start": 292,
+                          "end": 294,
+                          "name": "as",
+                          "decorators": [],
+                          "optional": false,
+                          "typeAnnotation": null
+                        },
+                        "value": {
+                          "type": "Identifier",
+                          "start": 292,
+                          "end": 294,
+                          "name": "as",
+                          "decorators": [],
+                          "typeAnnotation": null,
+                          "optional": false
+                        },
+                        "method": false,
+                        "shorthand": true,
+                        "computed": false,
+                        "optional": false
+                      }
+                    ],
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "start": 296,
+                      "end": 309,
+                      "typeAnnotation": {
+                        "type": "TSTypeLiteral",
+                        "start": 298,
+                        "end": 309,
+                        "members": [
+                          {
+                            "type": "TSPropertySignature",
+                            "start": 300,
+                            "end": 307,
+                            "key": {
+                              "type": "Identifier",
+                              "start": 300,
+                              "end": 302,
+                              "name": "as",
+                              "decorators": [],
+                              "optional": false,
+                              "typeAnnotation": null
+                            },
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "start": 302,
+                              "end": 307,
+                              "typeAnnotation": {
+                                "type": "TSTypeReference",
+                                "start": 304,
+                                "end": 307,
+                                "typeName": {
+                                  "type": "Identifier",
+                                  "start": 304,
+                                  "end": 307,
+                                  "name": "Tag",
+                                  "decorators": [],
+                                  "optional": false,
+                                  "typeAnnotation": null
+                                },
+                                "typeArguments": null
+                              }
+                            },
+                            "computed": false,
+                            "optional": false,
+                            "readonly": false,
+                            "accessibility": null,
+                            "static": false
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "body": {
+                  "type": "ParenthesizedExpression",
+                  "start": 314,
+                  "end": 359,
+                  "expression": {
+                    "type": "JSXElement",
+                    "start": 320,
+                    "end": 357,
+                    "openingElement": {
+                      "type": "JSXOpeningElement",
+                      "start": 320,
+                      "end": 328,
+                      "name": {
+                        "type": "JSXExpressionContainer",
+                        "start": 321,
+                        "end": 327,
+                        "expression": {
+                          "type": "Identifier",
+                          "start": 323,
+                          "end": 325,
+                          "name": "as",
+                          "decorators": [],
+                          "optional": false,
+                          "typeAnnotation": null
+                        }
+                      },
+                      "attributes": [],
+                      "selfClosing": false,
+                      "typeArguments": null
+                    },
+                    "children": [
+                      {
+                        "type": "JSXText",
+                        "start": 328,
+                        "end": 337,
+                        "value": "\n        ",
+                        "raw": "\n        "
+                      },
+                      {
+                        "type": "JSXElement",
+                        "start": 337,
+                        "end": 345,
+                        "openingElement": {
+                          "type": "JSXOpeningElement",
+                          "start": 337,
+                          "end": 345,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 338,
+                            "end": 342,
+                            "name": "span"
+                          },
+                          "attributes": [],
+                          "selfClosing": true,
+                          "typeArguments": null
+                        },
+                        "children": [],
+                        "closingElement": null
+                      },
+                      {
+                        "type": "JSXText",
+                        "start": 345,
+                        "end": 350,
+                        "value": "\n    ",
+                        "raw": "\n    "
+                      }
+                    ],
+                    "closingElement": {
+                      "type": "JSXClosingElement",
+                      "start": 350,
+                      "end": 357,
+                      "name": {
+                        "type": "JSXExpressionContainer",
+                        "start": 352,
+                        "end": 356,
+                        "expression": {
+                          "type": "Identifier",
+                          "start": 353,
+                          "end": 355,
+                          "name": "as",
+                          "decorators": [],
+                          "optional": false,
+                          "typeAnnotation": null
+                        }
+                      }
+                    }
+                  }
+                },
+                "expression": true,
+                "typeParameters": null,
+                "returnType": null
+              },
+              "definite": false
+            }
+          ],
+          "declare": false
+        },
+        "specifiers": [],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/lazy-destructuring.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/lazy-destructuring.snapshot.json
@@ -1,0 +1,557 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 306,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "TSTypeAliasDeclaration",
+        "start": 0,
+        "end": 55,
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 10,
+          "name": "Props",
+          "decorators": [],
+          "typeAnnotation": null,
+          "optional": false
+        },
+        "typeParameters": null,
+        "typeAnnotation": {
+          "type": "TSTypeLiteral",
+          "start": 13,
+          "end": 54,
+          "members": [
+            {
+              "type": "TSPropertySignature",
+              "start": 19,
+              "end": 33,
+              "key": {
+                "type": "Identifier",
+                "start": 19,
+                "end": 24,
+                "name": "title",
+                "decorators": [],
+                "optional": false,
+                "typeAnnotation": null
+              },
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 24,
+                "end": 32,
+                "typeAnnotation": {
+                  "type": "TSStringKeyword",
+                  "start": 26,
+                  "end": 32
+                }
+              },
+              "computed": false,
+              "optional": false,
+              "readonly": false,
+              "accessibility": null,
+              "static": false
+            },
+            {
+              "type": "TSPropertySignature",
+              "start": 38,
+              "end": 52,
+              "key": {
+                "type": "Identifier",
+                "start": 38,
+                "end": 43,
+                "name": "count",
+                "decorators": [],
+                "optional": false,
+                "typeAnnotation": null
+              },
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 43,
+                "end": 51,
+                "typeAnnotation": {
+                  "type": "TSNumberKeyword",
+                  "start": 45,
+                  "end": 51
+                }
+              },
+              "computed": false,
+              "optional": false,
+              "readonly": false,
+              "accessibility": null,
+              "static": false
+            }
+          ]
+        },
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 57,
+        "end": 84,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 71,
+            "end": 83,
+            "id": {
+              "type": "Identifier",
+              "start": 71,
+              "end": 83,
+              "name": "props",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 76,
+                "end": 83,
+                "typeAnnotation": {
+                  "type": "TSTypeReference",
+                  "start": 78,
+                  "end": 83,
+                  "typeName": {
+                    "type": "Identifier",
+                    "start": 78,
+                    "end": 83,
+                    "name": "Props",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "typeArguments": null
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 85,
+        "end": 116,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 99,
+            "end": 115,
+            "id": {
+              "type": "Identifier",
+              "start": 99,
+              "end": 115,
+              "name": "values",
+              "decorators": [],
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 105,
+                "end": 115,
+                "typeAnnotation": {
+                  "type": "TSArrayType",
+                  "start": 107,
+                  "end": 115,
+                  "elementType": {
+                    "type": "TSStringKeyword",
+                    "start": 107,
+                    "end": 113
+                  }
+                }
+              },
+              "optional": false
+            },
+            "init": null,
+            "definite": false
+          }
+        ],
+        "declare": true
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 118,
+        "end": 159,
+        "kind": "let",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 122,
+            "end": 158,
+            "id": {
+              "type": "ObjectPattern",
+              "start": 122,
+              "end": 150,
+              "properties": [
+                {
+                  "type": "Property",
+                  "start": 125,
+                  "end": 130,
+                  "kind": "init",
+                  "key": {
+                    "type": "Identifier",
+                    "start": 125,
+                    "end": 130,
+                    "name": "title",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 125,
+                    "end": 130,
+                    "name": "title",
+                    "decorators": [],
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "optional": false
+                },
+                {
+                  "type": "Property",
+                  "start": 132,
+                  "end": 148,
+                  "kind": "init",
+                  "key": {
+                    "type": "Identifier",
+                    "start": 132,
+                    "end": 137,
+                    "name": "count",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "value": {
+                    "type": "AssignmentPattern",
+                    "start": 139,
+                    "end": 148,
+                    "left": {
+                      "type": "Identifier",
+                      "start": 139,
+                      "end": 144,
+                      "name": "total",
+                      "decorators": [],
+                      "typeAnnotation": null,
+                      "optional": false
+                    },
+                    "right": {
+                      "type": "Literal",
+                      "start": 147,
+                      "end": 148,
+                      "value": 0,
+                      "raw": "0"
+                    },
+                    "decorators": [],
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "method": false,
+                  "shorthand": false,
+                  "computed": false,
+                  "optional": false
+                }
+              ],
+              "lazy": true,
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "init": {
+              "type": "Identifier",
+              "start": 153,
+              "end": 158,
+              "name": "props",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 160,
+        "end": 195,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 166,
+            "end": 194,
+            "id": {
+              "type": "ArrayPattern",
+              "start": 166,
+              "end": 185,
+              "elements": [
+                {
+                  "type": "Identifier",
+                  "start": 168,
+                  "end": 173,
+                  "name": "first",
+                  "decorators": [],
+                  "typeAnnotation": null,
+                  "optional": false
+                },
+                null,
+                {
+                  "type": "RestElement",
+                  "start": 177,
+                  "end": 184,
+                  "argument": {
+                    "type": "Identifier",
+                    "start": 180,
+                    "end": 184,
+                    "name": "rest",
+                    "decorators": [],
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "decorators": [],
+                  "typeAnnotation": null,
+                  "optional": false,
+                  "value": null
+                }
+              ],
+              "lazy": true,
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "init": {
+              "type": "Identifier",
+              "start": 188,
+              "end": 194,
+              "name": "values",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 197,
+        "end": 216,
+        "expression": {
+          "type": "AssignmentExpression",
+          "start": 197,
+          "end": 215,
+          "left": {
+            "type": "ObjectPattern",
+            "start": 197,
+            "end": 207,
+            "properties": [
+              {
+                "type": "Property",
+                "start": 200,
+                "end": 205,
+                "kind": "init",
+                "key": {
+                  "type": "Identifier",
+                  "start": 200,
+                  "end": 205,
+                  "name": "title",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "value": {
+                  "type": "Identifier",
+                  "start": 200,
+                  "end": 205,
+                  "name": "title",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "method": false,
+                "shorthand": true,
+                "computed": false,
+                "optional": false
+              }
+            ],
+            "lazy": true,
+            "decorators": [],
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "right": {
+            "type": "Identifier",
+            "start": 210,
+            "end": 215,
+            "name": "props",
+            "decorators": [],
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "operator": "="
+        },
+        "directive": null
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 217,
+        "end": 235,
+        "expression": {
+          "type": "AssignmentExpression",
+          "start": 217,
+          "end": 234,
+          "left": {
+            "type": "ArrayPattern",
+            "start": 217,
+            "end": 225,
+            "elements": [
+              {
+                "type": "Identifier",
+                "start": 219,
+                "end": 224,
+                "name": "first",
+                "decorators": [],
+                "optional": false,
+                "typeAnnotation": null
+              }
+            ],
+            "lazy": true,
+            "decorators": [],
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "right": {
+            "type": "Identifier",
+            "start": 228,
+            "end": 234,
+            "name": "values",
+            "decorators": [],
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "operator": "="
+        },
+        "directive": null
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 237,
+        "end": 305,
+        "declaration": {
+          "type": "FunctionDeclaration",
+          "start": 244,
+          "end": 305,
+          "id": {
+            "type": "Identifier",
+            "start": 253,
+            "end": 257,
+            "name": "pick",
+            "decorators": [],
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "generator": false,
+          "async": false,
+          "params": [
+            {
+              "type": "ObjectPattern",
+              "start": 258,
+              "end": 282,
+              "properties": [
+                {
+                  "type": "Property",
+                  "start": 261,
+                  "end": 273,
+                  "kind": "init",
+                  "key": {
+                    "type": "Identifier",
+                    "start": 261,
+                    "end": 266,
+                    "name": "title",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 268,
+                    "end": 273,
+                    "name": "label",
+                    "decorators": [],
+                    "typeAnnotation": null,
+                    "optional": false
+                  },
+                  "method": false,
+                  "shorthand": false,
+                  "computed": false,
+                  "optional": false
+                }
+              ],
+              "lazy": true,
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "start": 275,
+                "end": 282,
+                "typeAnnotation": {
+                  "type": "TSTypeReference",
+                  "start": 277,
+                  "end": 282,
+                  "typeName": {
+                    "type": "Identifier",
+                    "start": 277,
+                    "end": 282,
+                    "name": "Props",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "typeArguments": null
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start": 284,
+            "end": 305,
+            "body": [
+              {
+                "type": "ReturnStatement",
+                "start": 290,
+                "end": 303,
+                "argument": {
+                  "type": "Identifier",
+                  "start": 297,
+                  "end": 302,
+                  "name": "label",
+                  "decorators": [],
+                  "optional": false,
+                  "typeAnnotation": null
+                }
+              }
+            ]
+          },
+          "expression": false,
+          "typeParameters": null,
+          "returnType": null,
+          "declare": false
+        },
+        "specifiers": [],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/style-element.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/style-element.snapshot.json
@@ -1,0 +1,439 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 576,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 356,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 355,
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 10,
+              "name": "view",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 13,
+              "end": 355,
+              "expression": {
+                "type": "JSXElement",
+                "start": 19,
+                "end": 353,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 19,
+                  "end": 28,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 20,
+                    "end": 27,
+                    "name": "section"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 28,
+                    "end": 37,
+                    "value": "\n        ",
+                    "raw": "\n        "
+                  },
+                  {
+                    "type": "JSXStyleElement",
+                    "start": 37,
+                    "end": 286,
+                    "openingElement": {
+                      "type": "JSXOpeningElement",
+                      "start": 37,
+                      "end": 44,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 38,
+                        "end": 43,
+                        "name": "style"
+                      },
+                      "attributes": [],
+                      "selfClosing": false,
+                      "typeArguments": null
+                    },
+                    "children": [
+                      {
+                        "type": "StyleSheet",
+                        "start": 44,
+                        "end": 278,
+                        "source": "\n            .card {\n                color: red;\n            }\n\n            /* stays in css */\n            @media (min-width: 40rem) {\n                .card {\n                    display: grid;\n                }\n            }\n        "
+                      }
+                    ],
+                    "closingElement": {
+                      "type": "JSXClosingElement",
+                      "start": 278,
+                      "end": 286,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 280,
+                        "end": 285,
+                        "name": "style"
+                      }
+                    },
+                    "css": "\n            .card {\n                color: red;\n            }\n\n            /* stays in css */\n            @media (min-width: 40rem) {\n                .card {\n                    display: grid;\n                }\n            }\n        "
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 286,
+                    "end": 295,
+                    "value": "\n        ",
+                    "raw": "\n        "
+                  },
+                  {
+                    "type": "JSXElement",
+                    "start": 295,
+                    "end": 338,
+                    "openingElement": {
+                      "type": "JSXOpeningElement",
+                      "start": 295,
+                      "end": 321,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 296,
+                        "end": 303,
+                        "name": "article"
+                      },
+                      "attributes": [
+                        {
+                          "type": "JSXAttribute",
+                          "start": 304,
+                          "end": 320,
+                          "name": {
+                            "type": "JSXIdentifier",
+                            "start": 304,
+                            "end": 313,
+                            "name": "className"
+                          },
+                          "value": {
+                            "type": "Literal",
+                            "start": 314,
+                            "end": 320,
+                            "value": "card",
+                            "raw": "\"card\""
+                          }
+                        }
+                      ],
+                      "selfClosing": false,
+                      "typeArguments": null
+                    },
+                    "children": [
+                      {
+                        "type": "JSXText",
+                        "start": 321,
+                        "end": 328,
+                        "value": "content",
+                        "raw": "content"
+                      }
+                    ],
+                    "closingElement": {
+                      "type": "JSXClosingElement",
+                      "start": 328,
+                      "end": 338,
+                      "name": {
+                        "type": "JSXIdentifier",
+                        "start": 330,
+                        "end": 337,
+                        "name": "article"
+                      }
+                    }
+                  },
+                  {
+                    "type": "JSXText",
+                    "start": 338,
+                    "end": 343,
+                    "value": "\n    ",
+                    "raw": "\n    "
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 343,
+                  "end": 353,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 345,
+                    "end": 352,
+                    "name": "section"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 358,
+        "end": 417,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 364,
+            "end": 416,
+            "id": {
+              "type": "Identifier",
+              "start": 364,
+              "end": 374,
+              "name": "standalone",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXStyleElement",
+              "start": 377,
+              "end": 416,
+              "openingElement": {
+                "type": "JSXOpeningElement",
+                "start": 377,
+                "end": 384,
+                "name": {
+                  "type": "JSXIdentifier",
+                  "start": 378,
+                  "end": 383,
+                  "name": "style"
+                },
+                "attributes": [],
+                "selfClosing": false,
+                "typeArguments": null
+              },
+              "children": [
+                {
+                  "type": "StyleSheet",
+                  "start": 384,
+                  "end": 408,
+                  "source": ".inline { color: blue; }"
+                }
+              ],
+              "closingElement": {
+                "type": "JSXClosingElement",
+                "start": 408,
+                "end": 416,
+                "name": {
+                  "type": "JSXIdentifier",
+                  "start": 410,
+                  "end": 415,
+                  "name": "style"
+                }
+              },
+              "css": ".inline { color: blue; }"
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 419,
+        "end": 528,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 425,
+            "end": 527,
+            "id": {
+              "type": "Identifier",
+              "start": 425,
+              "end": 440,
+              "name": "from_code_block",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "JSXCodeBlock",
+              "start": 443,
+              "end": 527,
+              "body": [
+                {
+                  "type": "VariableDeclaration",
+                  "start": 450,
+                  "end": 471,
+                  "kind": "const",
+                  "declarations": [
+                    {
+                      "type": "VariableDeclarator",
+                      "start": 456,
+                      "end": 470,
+                      "id": {
+                        "type": "Identifier",
+                        "start": 456,
+                        "end": 460,
+                        "name": "tone",
+                        "decorators": [],
+                        "typeAnnotation": null,
+                        "optional": false
+                      },
+                      "init": {
+                        "type": "Literal",
+                        "start": 463,
+                        "end": 470,
+                        "value": "green",
+                        "raw": "\"green\""
+                      },
+                      "definite": false
+                    }
+                  ],
+                  "declare": false
+                }
+              ],
+              "render": {
+                "type": "JSXStyleElement",
+                "start": 476,
+                "end": 525,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 476,
+                  "end": 483,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 477,
+                    "end": 482,
+                    "name": "style"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "StyleSheet",
+                    "start": 483,
+                    "end": 517,
+                    "source": ".from-code-block { color: green; }"
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 517,
+                  "end": 525,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 519,
+                    "end": 524,
+                    "name": "style"
+                  }
+                },
+                "css": ".from-code-block { color: green; }"
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 530,
+        "end": 575,
+        "declaration": null,
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 539,
+            "end": 543,
+            "local": {
+              "type": "Identifier",
+              "start": 539,
+              "end": 543,
+              "name": "view",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 539,
+              "end": 543,
+              "name": "view",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          },
+          {
+            "type": "ExportSpecifier",
+            "start": 545,
+            "end": 555,
+            "local": {
+              "type": "Identifier",
+              "start": 545,
+              "end": 555,
+              "name": "standalone",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 545,
+              "end": 555,
+              "name": "standalone",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          },
+          {
+            "type": "ExportSpecifier",
+            "start": 557,
+            "end": 572,
+            "local": {
+              "type": "Identifier",
+              "start": 557,
+              "end": 572,
+              "name": "from_code_block",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 557,
+              "end": 572,
+              "name": "from_code_block",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          }
+        ],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/submodule-import.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/submodule-import.snapshot.json
@@ -1,0 +1,262 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 193,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "TSModuleDeclaration",
+        "start": 0,
+        "end": 73,
+        "id": {
+          "type": "Identifier",
+          "start": 7,
+          "end": 13,
+          "name": "server",
+          "decorators": [],
+          "typeAnnotation": null,
+          "optional": false
+        },
+        "kind": "module",
+        "declare": false,
+        "global": false,
+        "body": {
+          "type": "TSModuleBlock",
+          "start": 14,
+          "end": 73,
+          "body": [
+            {
+              "type": "ExportNamedDeclaration",
+              "start": 20,
+              "end": 71,
+              "declaration": {
+                "type": "FunctionDeclaration",
+                "start": 27,
+                "end": 71,
+                "id": {
+                  "type": "Identifier",
+                  "start": 36,
+                  "end": 40,
+                  "name": "load",
+                  "decorators": [],
+                  "typeAnnotation": null,
+                  "optional": false
+                },
+                "generator": false,
+                "async": false,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 43,
+                  "end": 71,
+                  "body": [
+                    {
+                      "type": "ReturnStatement",
+                      "start": 53,
+                      "end": 65,
+                      "argument": {
+                        "type": "Literal",
+                        "start": 60,
+                        "end": 64,
+                        "value": "ok",
+                        "raw": "\"ok\""
+                      }
+                    }
+                  ]
+                },
+                "expression": false,
+                "typeParameters": null,
+                "returnType": null,
+                "declare": false
+              },
+              "specifiers": [],
+              "source": null,
+              "attributes": [],
+              "exportKind": "value"
+            }
+          ]
+        }
+      },
+      {
+        "type": "ImportDeclaration",
+        "start": 75,
+        "end": 103,
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 84,
+            "end": 88,
+            "imported": {
+              "type": "Identifier",
+              "start": 84,
+              "end": 88,
+              "name": "load",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 84,
+              "end": 88,
+              "name": "load",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "importKind": "value"
+          }
+        ],
+        "source": {
+          "type": "Identifier",
+          "start": 96,
+          "end": 102,
+          "name": "server",
+          "decorators": [],
+          "optional": false,
+          "typeAnnotation": null
+        },
+        "attributes": [],
+        "phase": null,
+        "importKind": "value"
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 105,
+        "end": 192,
+        "declaration": {
+          "type": "FunctionDeclaration",
+          "start": 112,
+          "end": 192,
+          "id": {
+            "type": "Identifier",
+            "start": 121,
+            "end": 125,
+            "name": "View",
+            "decorators": [],
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "generator": false,
+          "async": false,
+          "params": [],
+          "body": {
+            "type": "JSXCodeBlock",
+            "start": 137,
+            "end": 192,
+            "body": [
+              {
+                "type": "VariableDeclaration",
+                "start": 144,
+                "end": 165,
+                "kind": "const",
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start": 150,
+                    "end": 164,
+                    "id": {
+                      "type": "Identifier",
+                      "start": 150,
+                      "end": 155,
+                      "name": "value",
+                      "decorators": [],
+                      "typeAnnotation": null,
+                      "optional": false
+                    },
+                    "init": {
+                      "type": "CallExpression",
+                      "start": 158,
+                      "end": 164,
+                      "callee": {
+                        "type": "Identifier",
+                        "start": 158,
+                        "end": 162,
+                        "name": "load",
+                        "decorators": [],
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      "arguments": [],
+                      "optional": false,
+                      "typeArguments": null
+                    },
+                    "definite": false
+                  }
+                ],
+                "declare": false
+              }
+            ],
+            "render": {
+              "type": "JSXElement",
+              "start": 170,
+              "end": 190,
+              "openingElement": {
+                "type": "JSXOpeningElement",
+                "start": 170,
+                "end": 176,
+                "name": {
+                  "type": "JSXIdentifier",
+                  "start": 171,
+                  "end": 175,
+                  "name": "span"
+                },
+                "attributes": [],
+                "selfClosing": false,
+                "typeArguments": null
+              },
+              "children": [
+                {
+                  "type": "JSXExpressionContainer",
+                  "start": 176,
+                  "end": 183,
+                  "expression": {
+                    "type": "Identifier",
+                    "start": 177,
+                    "end": 182,
+                    "name": "value",
+                    "decorators": [],
+                    "optional": false,
+                    "typeAnnotation": null
+                  }
+                }
+              ],
+              "closingElement": {
+                "type": "JSXClosingElement",
+                "start": 183,
+                "end": 190,
+                "name": {
+                  "type": "JSXIdentifier",
+                  "start": 185,
+                  "end": 189,
+                  "name": "span"
+                }
+              }
+            }
+          },
+          "expression": false,
+          "typeParameters": null,
+          "returnType": {
+            "type": "TSTypeAnnotation",
+            "start": 127,
+            "end": 136,
+            "typeAnnotation": {
+              "type": "TSUnknownKeyword",
+              "start": 129,
+              "end": 136
+            }
+          },
+          "declare": false
+        },
+        "specifiers": [],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/snapshots/text-entities.snapshot.json
+++ b/test/parser/misc/tsrx/snapshots/text-entities.snapshot.json
@@ -1,0 +1,116 @@
+{
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 94,
+    "sourceType": "module",
+    "hashbang": null,
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 75,
+        "kind": "const",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 74,
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 10,
+              "name": "view",
+              "decorators": [],
+              "typeAnnotation": null,
+              "optional": false
+            },
+            "init": {
+              "type": "ParenthesizedExpression",
+              "start": 13,
+              "end": 74,
+              "expression": {
+                "type": "JSXElement",
+                "start": 19,
+                "end": 72,
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "start": 19,
+                  "end": 22,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 20,
+                    "end": 21,
+                    "name": "p"
+                  },
+                  "attributes": [],
+                  "selfClosing": false,
+                  "typeArguments": null
+                },
+                "children": [
+                  {
+                    "type": "JSXText",
+                    "start": 22,
+                    "end": 68,
+                    "value": "\"ABB&<>'&unknown;",
+                    "raw": "\"ABB&<>'&unknown;"
+                  }
+                ],
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "start": 68,
+                  "end": 72,
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "start": 70,
+                    "end": 71,
+                    "name": "p"
+                  }
+                }
+              }
+            },
+            "definite": false
+          }
+        ],
+        "declare": false
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 77,
+        "end": 93,
+        "declaration": null,
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 86,
+            "end": 90,
+            "local": {
+              "type": "Identifier",
+              "start": 86,
+              "end": 90,
+              "name": "view",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 86,
+              "end": 90,
+              "name": "view",
+              "decorators": [],
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "exportKind": "value"
+          }
+        ],
+        "source": null,
+        "attributes": [],
+        "exportKind": "value"
+      }
+    ]
+  },
+  "comments": [],
+  "diagnostics": []
+}

--- a/test/parser/misc/tsrx/style-element.module.tsrx
+++ b/test/parser/misc/tsrx/style-element.module.tsrx
@@ -1,0 +1,26 @@
+const view = (
+    <section>
+        <style>
+            .card {
+                color: red;
+            }
+
+            /* stays in css */
+            @media (min-width: 40rem) {
+                .card {
+                    display: grid;
+                }
+            }
+        </style>
+        <article className="card">content</article>
+    </section>
+);
+
+const standalone = <style>.inline { color: blue; }</style>;
+
+const from_code_block = @{
+    const tone = "green";
+    <style>.from-code-block { color: green; }</style>
+};
+
+export { view, standalone, from_code_block };

--- a/test/parser/misc/tsrx/submodule-import.module.tsrx
+++ b/test/parser/misc/tsrx/submodule-import.module.tsrx
@@ -1,0 +1,12 @@
+module server {
+    export function load() {
+        return "ok";
+    }
+}
+
+import { load } from server;
+
+export function View(): unknown @{
+    const value = load();
+    <span>{value}</span>
+}

--- a/test/parser/misc/tsrx/template-return-invalid.module.tsrx
+++ b/test/parser/misc/tsrx/template-return-invalid.module.tsrx
@@ -1,0 +1,11 @@
+const child = (
+    <section>
+        @{
+            return <span>invalid</span>;
+        }
+    </section>
+);
+
+function render() @{
+    return <span>valid</span>;
+}

--- a/test/parser/misc/tsrx/text-entities.module.tsrx
+++ b/test/parser/misc/tsrx/text-entities.module.tsrx
@@ -1,0 +1,5 @@
+const view = (
+    <p>&quot;A&#x42;&#66;&amp;&lt;&gt;&apos;&unknown;</p>
+);
+
+export { view };

--- a/test/parser/results/test_parser_misc_js.txt
+++ b/test/parser/results/test_parser_misc_js.txt
@@ -12,7 +12,7 @@ error: Unexpected '=>'
    |                      ^^^^^
  2 | () => {}
    | ^^
- 3 | 
+ 3 |
    |
    = help: '=>' is only valid after a single identifier or a parenthesized parameter list
 
@@ -29,7 +29,7 @@ error: The left-hand side of '**' cannot be an unparenthesized await expression
    |
  1 | await promise ** 2;
    | ^^^^^^^^^^^^^
- 2 | 
+ 2 |
    |
    = help: Add parentheses to make precedence explicit, for example `(await x) ** y`.
 
@@ -83,7 +83,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
    |
  1 | export default using resource = Bun;
    |                      ^^^^^^^^
- 2 | 
+ 2 |
    |
    = help: Try inserting a semicolon here
 
@@ -103,7 +103,7 @@ error: Expected ';' after for-loop init, but found 'id'
  1 | for (using
  2 | id = value;;) {
    | ^^
- 3 | 
+ 3 |
    |
 
 ✓ test/parser/misc/js/hex-literal-with-separator.js
@@ -113,7 +113,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
  2 | import value from "pkg"
  3 | assert { type: "json" }
    |        ^
- 4 | 
+ 4 |
    |
    = help: Try inserting a semicolon here
 
@@ -128,7 +128,7 @@ error: Identifier cannot immediately follow a numeric literal
    |
  1 | 012_7
    | ^^^
- 2 | 
+ 2 |
    |
    = help: Try adding whitespace here between the number and identifier
 
@@ -139,7 +139,7 @@ error: Tagged template expressions are not permitted in an optional chain
    |
  1 | tagFunction?.pass``;
    |                  ^^
- 2 | 
+ 2 |
    |
    = help: Remove the optional chaining operator '?.' before the template literal or add parentheses.
 
@@ -150,7 +150,7 @@ error: Expected declaration after 'export', but found 'using'
    |
  1 | export using resource = Bun;
    |        ^^^^^
- 2 | 
+ 2 |
    |
 
 ✓ test/parser/misc/js/using-var.js
@@ -159,7 +159,7 @@ error: Expected a semicolon or an implicit semicolon after a statement, but foun
    |
  1 |  function *a() { (b) => { yield cool }; }
    |                                 ^^^^
- 2 | 
+ 2 |
    |
    = help: Try inserting a semicolon here
 

--- a/test/parser/results/test_parser_misc_ts.txt
+++ b/test/parser/results/test_parser_misc_ts.txt
@@ -1,8 +1,8 @@
 test/parser/misc/ts
 ===================
-Passed:       31/31 (100.00%)
+Passed:       34/34 (100.00%)
 Failed:       0
-AST mismatch: 0/31
+AST mismatch: 0/34
 
 ✓ test/parser/misc/ts/ambient-reserved-param.ts
 ✓ test/parser/misc/ts/as-satisfies-asi-before-postfix.ts
@@ -12,7 +12,7 @@ error: Invalid assignment target
 25 | // whole expression is still not assignable (oxc rejects this too).
 26 | f()! = b;
    | ^^^^
-27 | 
+27 |
    |
    = help: The expression behind a non-null or type assertion must itself be a simple assignment target, like an identifier or member access, not a call or other expression.
 
@@ -25,7 +25,7 @@ error: Expected 'class' keyword, but found 'abstract'
    |
  1 | const C = @x(() => 0) abstract class {};
    |                       ^^^^^^^^
- 2 | 
+ 2 |
    |
 
 ✓ test/parser/misc/ts/decorated-abstract-class-heritage.ts
@@ -33,10 +33,21 @@ error: Expected 'class' keyword, but found 'abstract'
 ✓ test/parser/misc/ts/decorated-export-abstract-class.module.ts
 ✓ test/parser/misc/ts/decorated-export-default-abstract-class-named.module.ts
 ✓ test/parser/misc/ts/decorated-export-default-abstract-class.module.ts
+✓ test/parser/misc/ts/dynamic-tag-outside-tsrx.tsx
+error: Expected JSX element name, but found '{'
+   |
+ 1 | const tag = "section";
+ 2 | const value = <{tag} />;
+   |                ^
+ 3 | const fallback = value;
+   |
+   = help: Dynamic JSX tag names are only enabled in TSRX files
+
+
 ✓ test/parser/misc/ts/empty-type-argument-list.ts
 error: A type argument list cannot be empty
    |
- 4 | 
+ 4 |
  5 | type A = Array<numbe<>>
    |                      ^^
  6 | type B = Array<numbe<> >
@@ -46,6 +57,17 @@ error: A type argument list cannot be empty
 ✓ test/parser/misc/ts/extends-non-null-assertion.ts
 ✓ test/parser/misc/ts/function-overloads.ts
 ✓ test/parser/misc/ts/jsx-fused-angle-type-args.tsx
+✓ test/parser/misc/ts/lazy-destructuring-outside-tsrx.ts
+error: Lazy destructuring patterns are only enabled in TSRX files
+   |
+ 1 | declare const props: { value: string };
+ 2 | const &{ value } = props;
+   |       ^
+ 3 |
+   |
+   = help: Use a .tsrx file or remove the '&' lazy-pattern marker.
+
+
 ✓ test/parser/misc/ts/optional-chain-call-fused-angle.ts
 ✓ test/parser/misc/ts/optional-chain-instantiation-fused-angle.ts
 ✓ test/parser/misc/ts/redeclare-error-class.ts
@@ -57,7 +79,7 @@ error: Identifier 'B1' has already been declared
  5 | class B1 {}
    |       ^^
    |       ~~ cannot be redeclared here
- 6 | 
+ 6 |
    |
    = help: Consider removing or renaming this declaration of 'B1'
 
@@ -89,7 +111,7 @@ error: Identifier 'D1' has already been declared
  7 | var D1 = 0;
    |     ^^
    |     ~~ cannot be redeclared here
- 8 | 
+ 8 |
    |
    = help: Consider removing or renaming this declaration of 'D1'
 
@@ -103,7 +125,7 @@ error: Identifier 'A1' has already been declared
  5 | type A1 = string;
    |      ^^
    |      ~~ cannot be redeclared here
- 6 | 
+ 6 |
    |
    = help: Consider removing or renaming this declaration of 'A1'
 
@@ -120,7 +142,7 @@ error: Identifier 'T7' has already been declared
 39 | import T7 from "./b";
    |        ^^
    |        ~~ cannot be redeclared here
-40 | 
+40 |
    |
    = help: Consider removing or renaming this declaration of 'T7'
 
@@ -129,3 +151,11 @@ error: Identifier 'T7' has already been declared
 ✓ test/parser/misc/ts/redeclare-merge-namespace.ts
 ✓ test/parser/misc/ts/redeclare-merge-overloads.ts
 ✓ test/parser/misc/ts/redeclare-type-parameter-scope.ts
+✓ test/parser/misc/ts/submodule-import-outside-tsrx.ts
+error: Identifier module specifiers require TSRX
+   |
+ 1 | import { load } from server;
+   |                      ^^^^^^
+ 2 |
+   |
+   = help: Use a .tsrx file for submodule imports such as import { load } from server.

--- a/test/parser/results/test_parser_misc_tsrx.txt
+++ b/test/parser/results/test_parser_misc_tsrx.txt
@@ -1,0 +1,49 @@
+test/parser/misc/tsrx
+=====================
+Passed:       12/15 (80.00%)
+Failed:       3
+AST mismatch: 0/12
+
+✓ test/parser/misc/tsrx/code-block-expression.module.tsrx
+✓ test/parser/misc/tsrx/code-block-function.module.tsrx
+✓ test/parser/misc/tsrx/code-block.module.tsrx
+✓ test/parser/misc/tsrx/control-flow-for.module.tsrx
+✓ test/parser/misc/tsrx/control-flow-if.module.tsrx
+✗ test/parser/misc/tsrx/control-flow-switch-invalid.module.tsrx (parse errors)
+error: `break` is invalid inside `@switch` cases.
+   |
+ 4 |     @case "ready": {
+ 5 |         break;
+   |         ^^^^^^
+ 6 |     }
+   |
+
+✓ test/parser/misc/tsrx/control-flow-switch.module.tsrx
+✓ test/parser/misc/tsrx/control-flow-try.module.tsrx
+✗ test/parser/misc/tsrx/dynamic-tag-invalid.module.tsrx (parse errors)
+error: TSRX dynamic tag expression must resolve to an element name
+   |
+ 3 |
+ 4 | const call_tag = <{getTag()} />;
+   |                   ^^^^^^^^^^
+ 5 | const concat_tag = <{"x" + name} />;
+   |
+   = help: Use an identifier, member expression, string literal, or conditional.
+
+
+✓ test/parser/misc/tsrx/dynamic-tag.module.tsrx
+✓ test/parser/misc/tsrx/lazy-destructuring.module.tsrx
+✓ test/parser/misc/tsrx/style-element.module.tsrx
+✓ test/parser/misc/tsrx/submodule-import.module.tsrx
+✗ test/parser/misc/tsrx/template-return-invalid.module.tsrx (parse errors)
+error: `return` is invalid inside TSRX template blocks
+   |
+ 3 |         @{
+ 4 |             return <span>invalid</span>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 5 |         }
+   |
+   = help: Use rendered output as the final expression instead.
+
+
+✓ test/parser/misc/tsrx/text-entities.module.tsrx

--- a/test/parser/run.ts
+++ b/test/parser/run.ts
@@ -70,6 +70,14 @@ const suites: TestSuite[] = [
     options: { semanticErrors: true },
   },
   {
+    path: `${MISC_DIR}/tsrx`,
+    expect: "snapshot",
+    lang: ["tsrx"],
+    recursive: false,
+    autoSnapshot: true,
+    options: { semanticErrors: true },
+  },
+  {
     path: `${MISC_DIR}/js/preserve-parens-disabled`,
     expect: "snapshot",
     lang: ["js"],

--- a/tools/estree/decoder.zig
+++ b/tools/estree/decoder.zig
@@ -1018,11 +1018,13 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8, comptime tag: usize) 
         const sr = comptime slotOf(ast.ArrayPattern, "rest");
         const sdec = comptime slotOf(ast.ArrayPattern, "decorators");
         const sta = comptime slotOf(ast.ArrayPattern, "type_annotation");
+        const mlazy = comptime flagMask(ast.ArrayPattern, "lazy");
         try emit(w,
             \\    case {d}: {{
             \\      const el = nodeArrHoles(f{d}, f0);
             \\      if (f{d} !== NULL) el.push(node(f{d}));
             \\      const r = {{ type: "ArrayPattern", start, end, elements: el }};
+            \\      if (flags & {d}) r.lazy = true;
             \\      if (_isTs) {{
             \\        r.decorators = nodeArr(f{d}, f{d});
             \\        r.optional = !!(flags & {d});
@@ -1031,20 +1033,22 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8, comptime tag: usize) 
             \\      return r;
             \\    }}
         , .{
-            tag,  se,       sr,                                              sr,
-            sdec, sdec + 1, comptime flagMask(ast.ArrayPattern, "optional"), sta,
-            sta,
+            tag,   se,   sr,       sr,
+            mlazy, sdec, sdec + 1, comptime flagMask(ast.ArrayPattern, "optional"),
+            sta,   sta,
         });
     } else if (comptime eql(u8, name, "object_pattern")) {
         const sp = comptime slotOf(ast.ObjectPattern, "properties");
         const sr = comptime slotOf(ast.ObjectPattern, "rest");
         const sdec = comptime slotOf(ast.ObjectPattern, "decorators");
         const sta = comptime slotOf(ast.ObjectPattern, "type_annotation");
+        const mlazy = comptime flagMask(ast.ObjectPattern, "lazy");
         try emit(w,
             \\    case {d}: {{
             \\      const pr = nodeArr(f{d}, f0);
             \\      if (f{d} !== NULL) pr.push(node(f{d}));
             \\      const r = {{ type: "ObjectPattern", start, end, properties: pr }};
+            \\      if (flags & {d}) r.lazy = true;
             \\      if (_isTs) {{
             \\        r.decorators = nodeArr(f{d}, f{d});
             \\        r.optional = !!(flags & {d});
@@ -1053,9 +1057,9 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8, comptime tag: usize) 
             \\      return r;
             \\    }}
         , .{
-            tag,  sp,       sr,                                               sr,
-            sdec, sdec + 1, comptime flagMask(ast.ObjectPattern, "optional"), sta,
-            sta,
+            tag,   sp,   sr,       sr,
+            mlazy, sdec, sdec + 1, comptime flagMask(ast.ObjectPattern, "optional"),
+            sta,   sta,
         });
     } else if (comptime eql(u8, name, "jsx_text")) {
         const sv = comptime slotOf(ast.JSXText, "value");

--- a/tools/estree/encoder.zig
+++ b/tools/estree/encoder.zig
@@ -947,6 +947,7 @@ fn writeSpecialArrayPattern(w: *Writer, comptime tag: usize) !void {
     const sr = comptime slotOf(T, "rest");
     const sdec = comptime slotOf(T, "decorators");
     const sta = comptime slotOf(T, "type_annotation");
+    const mlazy = comptime flagMask(T, "lazy");
     const mopt = comptime flagMask(T, "optional");
     try w.print(
         \\  function enc_array_pattern(n) {{
@@ -969,13 +970,13 @@ fn writeSpecialArrayPattern(w: *Writer, comptime tag: usize) !void {
         \\    slotAt(idx, {d}, rest);
         \\    slotAt(idx, {d}, decs.start); slotAt(idx, {d}, decs.len);
         \\    slotAt(idx, {d}, ta);
-        \\    flagsAt(idx, n.optional ? {d} : 0);
+        \\    flagsAt(idx, (n.lazy ? {d} : 0) | (n.optional ? {d} : 0));
         \\    spanAt(idx, asStart(n), asEnd(n));
         \\    recordComments(n, idx);
         \\    return idx;
         \\  }}
         \\
-    , .{ tag, sr, sdec, sdec + 1, sta, mopt });
+    , .{ tag, sr, sdec, sdec + 1, sta, mlazy, mopt });
 }
 
 fn writeSpecialObjectPattern(w: *Writer, comptime tag: usize) !void {
@@ -983,6 +984,7 @@ fn writeSpecialObjectPattern(w: *Writer, comptime tag: usize) !void {
     const sr = comptime slotOf(T, "rest");
     const sdec = comptime slotOf(T, "decorators");
     const sta = comptime slotOf(T, "type_annotation");
+    const mlazy = comptime flagMask(T, "lazy");
     const mopt = comptime flagMask(T, "optional");
     try w.print(
         \\  function enc_object_pattern(n) {{
@@ -1004,13 +1006,13 @@ fn writeSpecialObjectPattern(w: *Writer, comptime tag: usize) !void {
         \\    slotAt(idx, {d}, rest);
         \\    slotAt(idx, {d}, decs.start); slotAt(idx, {d}, decs.len);
         \\    slotAt(idx, {d}, ta);
-        \\    flagsAt(idx, n.optional ? {d} : 0);
+        \\    flagsAt(idx, (n.lazy ? {d} : 0) | (n.optional ? {d} : 0));
         \\    spanAt(idx, asStart(n), asEnd(n));
         \\    recordComments(n, idx);
         \\    return idx;
         \\  }}
         \\
-    , .{ tag, sr, sdec, sdec + 1, sta, mopt });
+    , .{ tag, sr, sdec, sdec + 1, sta, mlazy, mopt });
 }
 
 fn writeSpecialProgram(w: *Writer, comptime tag: usize) !void {


### PR DESCRIPTION
## Summary

- adds `.tsrx` language mode and parser support for TSRX syntax
- supports dynamic tags, lazy destructuring, code blocks, template control flow, raw style elements, submodule imports, and JSX text entities
- updates codegen, npm/wasm surfaces, docs, fixtures, and snapshots
- splits TSRX parser logic into `syntax/tsrx/` to keep JSX root smaller

## Tests

- `zig build test`
- `bun test/parser/run.ts`
- `bun test test/codegen`