### PR TITLE
fix(parser): preserve large AST ranges in wire format

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "jest-diff": "^30.4.1",
         "napi-zig": "^0.1.45",
         "typescript": "^6.0.3",
+        "vitest": "^4.1.10",
         "yuku-analyzer": "workspace:*",
         "yuku-codegen": "workspace:*",
         "yuku-parser": "workspace:*",
@@ -226,6 +227,12 @@
     },
   },
   "packages": {
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
     "@jest/diff-sequences": ["@jest/diff-sequences@30.4.0", "", {}, "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g=="],
 
     "@jest/get-type": ["@jest/get-type@30.1.0", "", {}, "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA=="],
@@ -238,11 +245,71 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
     "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
     "@yuku-analyzer/binding-darwin-arm64": ["@yuku-analyzer/binding-darwin-arm64@workspace:npm/yuku-analyzer/@yuku-analyzer/binding-darwin-arm64"],
 
@@ -318,9 +385,13 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -328,7 +399,21 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -336,9 +421,47 @@
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
     "napi-zig": ["napi-zig@0.1.45", "", { "dependencies": { "cac": "^7.0.0", "package-manager-detector": "^1.6.0", "prompts": "^2.4.2", "semver": "^7.7.4" }, "bin": { "napi-zig": "dist/index.js" } }, "sha512-2cr7S+Mgz4RLN/l8vpqxJY7dbzcZEkQwMXBy4YEhQ0jvydtAgTfF66jfYQv22TSy16sC53h/QbUP85UhAfl4zQ=="],
 
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
     "package-manager-detector": ["package-manager-detector@1.7.0", "", {}, "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 
     "pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
@@ -348,15 +471,41 @@
 
     "react-is-19": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
 
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
+
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "yuku-analyzer": ["yuku-analyzer@workspace:npm/yuku-analyzer"],
 

--- a/npm/yuku-analyzer/decode.js
+++ b/npm/yuku-analyzer/decode.js
@@ -691,9 +691,8 @@ function decode(buffer, source) {
     return r;
   }
   function fnParams(idx) {
-    const po = _nodesOff + idx * 48;
-    const len = _u8[po + 4] | (_u8[po + 5] << 8);
-    const pb = po >> 2;
+    const pb = (_nodesOff + idx * 48) >> 2;
+    const len = _u32[pb + 1] >>> 0;
     const iStart = _u32[pb + 2], rest = _u32[pb + 3];
     const p = [];
     for (let j = 0; j < len; j++) p.push(node(_u32[_extraBase + iStart + j]));
@@ -730,7 +729,7 @@ function decode(buffer, source) {
     const h0 = _u32[b];
     const tag = h0 & 255;
     const flags = h0 >>> 16;
-    const f0 = _u32[b + 1] & 65535;
+    const f0 = _u32[b + 1] >>> 0;
     const f1 = _u32[b + 2], f2 = _u32[b + 3],
           f3 = _u32[b + 4], f4 = _u32[b + 5],
           f5 = _u32[b + 6], f6 = _u32[b + 7],
@@ -1238,7 +1237,7 @@ function decode(buffer, source) {
           const s = _u32[b + slot];
           const len = ops[q] === 1
             ? _u32[b + slot + 1]
-            : _u8[o + 4] | (_u8[o + 5] << 8);
+            : _u32[b + 1] >>> 0;
           for (let j = 0; j < len; j++) {
             const c = _u32[_extraBase + s + j];
             if (c !== NULL) visit(c, parent);

--- a/npm/yuku-codegen-wasm/encode.js
+++ b/npm/yuku-codegen-wasm/encode.js
@@ -72,8 +72,8 @@ function encode(program) {
     nU8[o] = v & 0xFF; nU8[o + 1] = (v >>> 8) & 0xFF;
   }
   function f0At(idx, v) {
-    const o = idx * NODE_SIZE + NODE_FIELD0_OFFSET;
-    nU8[o] = v & 0xFF; nU8[o + 1] = (v >>> 8) & 0xFF;
+    const b = (idx * NODE_SIZE) >>> 2;
+    nU32[b + (NODE_FIELD0_OFFSET >>> 2)] = v >>> 0;
   }
   function slotAt(idx, slot, v) {
     nU32[((idx * NODE_SIZE) >>> 2) + NODE_HEADER_U32S + slot] = v >>> 0;

--- a/npm/yuku-codegen/encode.js
+++ b/npm/yuku-codegen/encode.js
@@ -72,8 +72,8 @@ function encode(program) {
     nU8[o] = v & 0xFF; nU8[o + 1] = (v >>> 8) & 0xFF;
   }
   function f0At(idx, v) {
-    const o = idx * NODE_SIZE + NODE_FIELD0_OFFSET;
-    nU8[o] = v & 0xFF; nU8[o + 1] = (v >>> 8) & 0xFF;
+    const b = (idx * NODE_SIZE) >>> 2;
+    nU32[b + (NODE_FIELD0_OFFSET >>> 2)] = v >>> 0;
   }
   function slotAt(idx, slot, v) {
     nU32[((idx * NODE_SIZE) >>> 2) + NODE_HEADER_U32S + slot] = v >>> 0;

--- a/npm/yuku-parser-wasm/decode.js
+++ b/npm/yuku-parser-wasm/decode.js
@@ -313,9 +313,8 @@ function decode(buffer, source) {
     return r;
   }
   function fnParams(idx) {
-    const po = _nodesOff + idx * 48;
-    const len = _u8[po + 4] | (_u8[po + 5] << 8);
-    const pb = po >> 2;
+    const pb = (_nodesOff + idx * 48) >> 2;
+    const len = _u32[pb + 1] >>> 0;
     const iStart = _u32[pb + 2], rest = _u32[pb + 3];
     const p = [];
     for (let j = 0; j < len; j++) p.push(node(_u32[_extraBase + iStart + j]));
@@ -352,7 +351,7 @@ function decode(buffer, source) {
     const h0 = _u32[b];
     const tag = h0 & 255;
     const flags = h0 >>> 16;
-    const f0 = _u32[b + 1] & 65535;
+    const f0 = _u32[b + 1] >>> 0;
     const f1 = _u32[b + 2], f2 = _u32[b + 3],
           f3 = _u32[b + 4], f4 = _u32[b + 5],
           f5 = _u32[b + 6], f6 = _u32[b + 7],

--- a/npm/yuku-parser/decode.js
+++ b/npm/yuku-parser/decode.js
@@ -313,9 +313,8 @@ function decode(buffer, source) {
     return r;
   }
   function fnParams(idx) {
-    const po = _nodesOff + idx * 48;
-    const len = _u8[po + 4] | (_u8[po + 5] << 8);
-    const pb = po >> 2;
+    const pb = (_nodesOff + idx * 48) >> 2;
+    const len = _u32[pb + 1] >>> 0;
     const iStart = _u32[pb + 2], rest = _u32[pb + 3];
     const p = [];
     for (let j = 0; j < len; j++) p.push(node(_u32[_extraBase + iStart + j]));
@@ -352,7 +351,7 @@ function decode(buffer, source) {
     const h0 = _u32[b];
     const tag = h0 & 255;
     const flags = h0 >>> 16;
-    const f0 = _u32[b + 1] & 65535;
+    const f0 = _u32[b + 1] >>> 0;
     const f1 = _u32[b + 2], f2 = _u32[b + 3],
           f3 = _u32[b + 4], f4 = _u32[b + 5],
           f5 = _u32[b + 6], f6 = _u32[b + 7],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "test": "bun fetch:fixtures && bun build:local && bun test:parser && bun test:codegen && bun test:analyzer && bun test:sourcemap",
-    "test:parser": "bun test/parser/run.ts",
+    "test:parser": "bun test/parser/run.ts && bun test:parser:large-ast",
+    "test:parser:large-ast": "zig build wasm && vitest run test/parser/large-ast.test.ts",
     "test:codegen": "bun test test/codegen",
     "test:analyzer": "bun test test/analyzer",
     "test:sourcemap": "bun test/sourcemap/run.ts",
@@ -40,6 +41,7 @@
     "jest-diff": "^30.4.1",
     "napi-zig": "^0.1.45",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.10",
     "yuku-analyzer": "workspace:*",
     "yuku-codegen": "workspace:*",
     "yuku-parser": "workspace:*"

--- a/src/parser/ffi/transfer/root.zig
+++ b/src/parser/ffi/transfer/root.zig
@@ -54,7 +54,7 @@
 //   bool              1 flag bit, at the running sum of prior flag widths.
 //   enum              ceil(log2(n)) flag bits, where n is the variant count.
 //   NodeIndex         1 u32 slot. 0xFFFFFFFF marks null.
-//   IndexRange        the first such field in a struct takes field0 (u16
+//   IndexRange        the first such field in a struct takes field0 (u32
 //                     length) plus 1 u32 slot for start; each later one
 //                     takes 2 u32 slots, start then length.
 //   String            2 u32 slots (start, end); see string handles below.
@@ -134,7 +134,7 @@ const Header = extern struct {
 /// `flags` holds packed booleans and small enums, and `field1..field8`
 /// are u32 data slots assigned to struct fields by the packing rules.
 ///
-/// the *first* IndexRange in a struct uses `field0` (u16 length) plus one
+/// the *first* IndexRange in a struct uses `field0` (u32 length) plus one
 /// u32 slot for start, saving one full slot. every *later* IndexRange
 /// uses two consecutive u32 slots for start then length. this only
 /// affects structs with two or more IndexRange fields. the comptime
@@ -144,8 +144,7 @@ const PackedNode = extern struct {
     tag: u8,
     _pad0: u8 = 0,
     flags: u16,
-    field0: u16,
-    _pad1: u16 = 0,
+    field0: u32,
     field1: u32,
     field2: u32,
     field3: u32,
@@ -243,6 +242,9 @@ pub const ATTACHED_COMMENT_VALUE_START_OFFSET: u8 = @offsetOf(PackedAttachedComm
 pub const ATTACHED_COMMENT_VALUE_END_OFFSET: u8 = @offsetOf(PackedAttachedComment, "value_end");
 
 comptime {
+    std.debug.assert(NODE_SIZE == 48);
+    std.debug.assert(NODE_FIELD0_OFFSET == 4);
+    std.debug.assert(NODE_HEADER_U32S == 2);
     validateAllNodeLayouts();
 }
 
@@ -527,7 +529,7 @@ fn packPayload(n: *PackedNode, payload: anytype) void {
             setSlot(n, slot, @intFromEnum(val));
         } else if (f.type == ast.IndexRange) {
             if (comptime isFirstRange(T, i)) {
-                n.field0 = @intCast(val.len);
+                n.field0 = val.len;
                 setSlot(n, slot, val.start);
             } else {
                 setSlot(n, slot, val.start);

--- a/test/parser/large-ast.test.ts
+++ b/test/parser/large-ast.test.ts
@@ -1,0 +1,201 @@
+// exercises large first IndexRange fields through parser, codegen, and decoder boundaries
+// repeated tokens keep every boundary length and representative span deterministic
+
+import { copyFile } from "node:fs/promises";
+import { describe, expect, test } from "vitest";
+import { Analyzer } from "../../npm/yuku-analyzer/index.js";
+import { print } from "../../npm/yuku-codegen/index.js";
+import { parse } from "../../npm/yuku-parser/index.js";
+
+await Promise.all([
+    copyFile(
+        new URL("../../zig-out/bin/yuku-parser.wasm", import.meta.url),
+        new URL("../../npm/yuku-parser-wasm/yuku-parser.wasm", import.meta.url),
+    ),
+    copyFile(
+        new URL("../../zig-out/bin/yuku-codegen.wasm", import.meta.url),
+        new URL("../../npm/yuku-codegen-wasm/yuku-codegen.wasm", import.meta.url),
+    ),
+]);
+
+const { parse: parseWasm } = await import("../../npm/yuku-parser-wasm/index.js");
+const { print: printWasm } = await import("../../npm/yuku-codegen-wasm/index.js");
+
+const parseOptions = {
+    sourceType: "module",
+    lang: "js",
+    preserveParens: true,
+    allowReturnOutsideFunction: false,
+    semanticErrors: false,
+    attachComments: false,
+} as const;
+const analyzerFileOptions = {
+    sourceType: "module",
+    lang: "js",
+    preserveParens: true,
+    allowReturnOutsideFunction: false,
+    attachComments: false,
+} as const;
+const codegenOptions = {
+    format: "compact",
+    indent: 2,
+    quotes: "preserve",
+    sourceMaps: undefined,
+    comments: "some",
+} as const;
+
+describe("large AST ranges", () => {
+    test.each([65_535, 65_536, 65_537, 70_000])(
+        "preserves %i top-level statements",
+        (statementCount) => {
+            const result = parse(";".repeat(statementCount), parseOptions);
+            const middle = Math.floor(statementCount / 2);
+
+            expect(result.diagnostics).toHaveLength(0);
+            expect(result.program.body).toHaveLength(statementCount);
+            expect(result.program.body[0]).toMatchObject({
+                type: "EmptyStatement",
+                start: 0,
+                end: 1,
+            });
+            expect(result.program.body[middle]).toMatchObject({
+                type: "EmptyStatement",
+                start: middle,
+                end: middle + 1,
+            });
+            expect(result.program.body[statementCount - 1]).toMatchObject({
+                type: "EmptyStatement",
+                start: statementCount - 1,
+                end: statementCount,
+            });
+        },
+    );
+
+    test("preserves 65,536 statements in a block", () => {
+        const statementCount = 65_536;
+        const source = `{${";".repeat(statementCount)}}`;
+        const result = parse(source, parseOptions);
+        const block = result.program.body[0];
+
+        expect(result.diagnostics).toHaveLength(0);
+        expect(block).toMatchObject({
+            type: "BlockStatement",
+            start: 0,
+            end: source.length,
+        });
+        if (block?.type !== "BlockStatement") throw new Error("Expected a block statement");
+        expect(block.body).toHaveLength(statementCount);
+        expect(block.body[0]).toMatchObject({ type: "EmptyStatement", start: 1, end: 2 });
+        expect(block.body[32_768]).toMatchObject({
+            type: "EmptyStatement",
+            start: 32_769,
+            end: 32_770,
+        });
+        expect(block.body[65_535]).toMatchObject({
+            type: "EmptyStatement",
+            start: 65_536,
+            end: 65_537,
+        });
+    });
+
+    test("preserves 65,536 array elements", () => {
+        const elementCount = 65_536;
+        const source = `[${"0,".repeat(elementCount - 1)}0]`;
+        const result = parse(source, parseOptions);
+        const statement = result.program.body[0];
+
+        expect(result.diagnostics).toHaveLength(0);
+        if (statement?.type !== "ExpressionStatement") {
+            throw new Error("Expected an expression statement");
+        }
+        const expression = statement.expression;
+        if (expression.type !== "ArrayExpression") throw new Error("Expected an array expression");
+        expect(expression.elements).toHaveLength(elementCount);
+        expect(expression.elements[0]).toMatchObject({ type: "Literal", start: 1, end: 2 });
+        expect(expression.elements[32_768]).toMatchObject({
+            type: "Literal",
+            start: 65_537,
+            end: 65_538,
+        });
+        expect(expression.elements[65_535]).toMatchObject({
+            type: "Literal",
+            start: 131_071,
+            end: 131_072,
+        });
+    });
+
+    test("preserves 65,536 function parameters", () => {
+        const parameterCount = 65_536;
+        const source = `function f(${"a,".repeat(parameterCount - 1)}a){}`;
+        const result = parse(source, parseOptions);
+        const declaration = result.program.body[0];
+
+        expect(result.diagnostics).toHaveLength(0);
+        if (declaration?.type !== "FunctionDeclaration") {
+            throw new Error("Expected a function declaration");
+        }
+        expect(declaration.params).toHaveLength(parameterCount);
+        expect(declaration.params[0]).toMatchObject({ type: "Identifier", start: 11, end: 12 });
+        expect(declaration.params[32_768]).toMatchObject({
+            type: "Identifier",
+            start: 65_547,
+            end: 65_548,
+        });
+        expect(declaration.params[65_535]).toMatchObject({
+            type: "Identifier",
+            start: 131_081,
+            end: 131_082,
+        });
+    });
+
+    test("prints 65,536 top-level statements", () => {
+        const statementCount = 65_536;
+        const program = parse(";".repeat(statementCount), parseOptions).program;
+        const printed = print(program, codegenOptions);
+
+        expect(printed.errors).toHaveLength(0);
+        expect(parse(printed.code, parseOptions).program.body).toHaveLength(statementCount);
+    });
+
+    test("analyzes parent links for 65,536 top-level statements", () => {
+        const statementCount = 65_536;
+        const analyzer = new Analyzer({ resolve: () => null });
+        const module = analyzer.addFile(
+            "large.js",
+            ";".repeat(statementCount),
+            analyzerFileOptions,
+        );
+        const lastStatement = module.ast.body[statementCount - 1];
+
+        expect(module.diagnostics).toHaveLength(0);
+        expect(module.ast.body).toHaveLength(statementCount);
+        expect(lastStatement).toMatchObject({
+            type: "EmptyStatement",
+            start: statementCount - 1,
+            end: statementCount,
+        });
+        expect(lastStatement).toBeDefined();
+        expect(module.parentOf(lastStatement!)).toBe(module.ast);
+    });
+
+    test("parses 65,536 top-level statements with WebAssembly", () => {
+        const statementCount = 65_536;
+        const result = parseWasm(";".repeat(statementCount), parseOptions);
+
+        expect(result.diagnostics).toHaveLength(0);
+        expect(result.program.body).toHaveLength(statementCount);
+        expect(result.program.body[statementCount - 1]).toMatchObject({
+            type: "EmptyStatement",
+            start: statementCount - 1,
+            end: statementCount,
+        });
+    });
+
+    test("prints 65,536 top-level statements with WebAssembly", () => {
+        const statementCount = 65_536;
+        const program = parse(";".repeat(statementCount), parseOptions).program;
+        const code = printWasm(program);
+
+        expect(parse(code, parseOptions).program.body).toHaveLength(statementCount);
+    });
+});

--- a/tools/estree/decoder.zig
+++ b/tools/estree/decoder.zig
@@ -256,9 +256,8 @@ fn writeDecodeOpen(w: *Writer) !void {
         \\    return r;
         \\  }}
         \\  function fnParams(idx) {{
-        \\    const po = _nodesOff + idx * {[size]d};
-        \\    const len = _u8[po + {[f0]d}] | (_u8[po + {[f01]d}] << 8);
-        \\    const pb = po >> 2;
+        \\    const pb = (_nodesOff + idx * {[size]d}) >> 2;
+        \\    const len = _u32[pb + {[f0]d}] >>> 0;
         \\    const iStart = _u32[pb + {[items]d}], rest = _u32[pb + {[rest]d}];
         \\    const p = [];
         \\    for (let j = 0; j < len; j++) p.push(node(_u32[_extraBase + iStart + j]));
@@ -282,8 +281,7 @@ fn writeDecodeOpen(w: *Writer) !void {
         .hdr = rt.HEADER_SIZE,
         .size = rt.NODE_SIZE,
         .acsize = rt.ATTACHED_COMMENT_SIZE,
-        .f0 = rt.NODE_FIELD0_OFFSET,
-        .f01 = rt.NODE_FIELD0_OFFSET + 1,
+        .f0 = rt.NODE_FIELD0_OFFSET / 4,
         .items = comptime u32IndexOf(ast.FormalParameters, "items"),
         .rest = comptime u32IndexOf(ast.FormalParameters, "rest"),
     });
@@ -299,9 +297,10 @@ fn u16At(comptime word: []const u8, comptime byte_in_word: u8) []const u8 {
 fn writeNodeFunction(w: *Writer, mode: Mode) !void {
     comptime std.debug.assert(rt.NODE_FLAGS_OFFSET / 4 == 0);
     const flags_expr = comptime u16At("h0", rt.NODE_FLAGS_OFFSET % 4);
-    const f0_expr = comptime u16At(
-        std.fmt.comptimePrint("_u32[b + {d}]", .{rt.NODE_FIELD0_OFFSET / 4}),
-        rt.NODE_FIELD0_OFFSET % 4,
+    comptime std.debug.assert(rt.NODE_FIELD0_OFFSET % 4 == 0);
+    const f0_expr = comptime std.fmt.comptimePrint(
+        "_u32[b + {d}] >>> 0",
+        .{rt.NODE_FIELD0_OFFSET / 4},
     );
     try w.print(
         \\  function _attachedCommentsOf(a, e) {{
@@ -1357,7 +1356,7 @@ fn writeParentBody(w: *Writer) !void {
         \\          const s = _u32[b + slot];
         \\          const len = ops[q] === 1
         \\            ? _u32[b + slot + 1]
-        \\            : _u8[o + {[f0]d}] | (_u8[o + {[f01]d}] << 8);
+        \\            : _u32[b + {[f0]d}] >>> 0;
         \\          for (let j = 0; j < len; j++) {{
         \\            const c = _u32[_extraBase + s + j];
         \\            if (c !== NULL) visit(c, parent);
@@ -1370,8 +1369,7 @@ fn writeParentBody(w: *Writer) !void {
         \\
     , .{
         .size = rt.NODE_SIZE,
-        .f0 = rt.NODE_FIELD0_OFFSET,
-        .f01 = rt.NODE_FIELD0_OFFSET + 1,
+        .f0 = rt.NODE_FIELD0_OFFSET / 4,
     });
 }
 

--- a/tools/estree/encoder.zig
+++ b/tools/estree/encoder.zig
@@ -9,6 +9,7 @@ const Writer = std.Io.Writer;
 // generates encode.js, the inverse of decode.js, walks ESTree and writes the v7 wire-format buffer
 pub fn generate(w: *Writer) !void {
     @setEvalBranchQuota(500_000);
+    comptime std.debug.assert(rt.NODE_FIELD0_OFFSET % 4 == 0);
     try writePrologue(w);
     try writeInverseMaps(w);
     try writeRuntime(w);
@@ -130,8 +131,8 @@ fn writeRuntime(w: *Writer) !void {
         \\    nU8[o] = v & 0xFF; nU8[o + 1] = (v >>> 8) & 0xFF;
         \\  }
         \\  function f0At(idx, v) {
-        \\    const o = idx * NODE_SIZE + NODE_FIELD0_OFFSET;
-        \\    nU8[o] = v & 0xFF; nU8[o + 1] = (v >>> 8) & 0xFF;
+        \\    const b = (idx * NODE_SIZE) >>> 2;
+        \\    nU32[b + (NODE_FIELD0_OFFSET >>> 2)] = v >>> 0;
         \\  }
         \\  function slotAt(idx, slot, v) {
         \\    nU32[((idx * NODE_SIZE) >>> 2) + NODE_HEADER_U32S + slot] = v >>> 0;


### PR DESCRIPTION
## Summary

- widen the packed first `IndexRange.len` from `u16` to `u32`, consuming the existing padding so `PackedNode` remains 48 bytes
- update the parser/analyzer decoders and codegen encoders for the native and WebAssembly packages
- add Vitest coverage around the 65,535 boundary and across parser, analyzer, codegen, and WebAssembly paths

## Why

The previous wire layout stored the first range length in 16 bits. A list containing 65,536 children could therefore decode as empty, while larger lists could silently retain only `length % 65,536` children.

## Testing

- `bun run test`
- `zig build test`
- `bun run test:parser:large-ast` (11 tests)
- strict TypeScript checking for the new Vitest suite