### PR TITLE
Add `sideEffects: false` field to `yuku-ast`

### DIFF
--- a/npm/yuku-ast/package.json
+++ b/npm/yuku-ast/package.json
@@ -37,5 +37,6 @@
     "javascript",
     "yuku"
   ],
-  "module": "./dist/index.js"
+  "module": "./dist/index.js",
+  "sideEffects": false
 }


### PR DESCRIPTION
Prettier bundles `@yuku-parser/wasm`, it re-exports `WalkContext` and `walk` from `yuku-ast`, without this change, ESBuild is not able to tree-shake code from it.

I suggest adding `sideEffects: false` to all packages, but this is the only one I need.

The bundler size increased 15Kb for v0.6.9 https://github.com/prettier/prettier/pull/19664