### PR TITLE
provide license field for binding packages

### DIFF
--- a/npm/yuku-analyzer/@yuku-analyzer/binding-darwin-arm64/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-darwin-arm64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-darwin-arm64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "darwin"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-darwin-x64/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-darwin-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-darwin-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "darwin"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-freebsd-x64/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-freebsd-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-freebsd-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "freebsd"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-linux-arm-gnu/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-linux-arm-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-linux-arm-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-linux-arm-musl/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-linux-arm-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-linux-arm-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-linux-arm64-gnu/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-linux-arm64-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-linux-arm64-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-linux-arm64-musl/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-linux-arm64-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-linux-arm64-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-linux-x64-gnu/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-linux-x64-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-linux-x64-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-linux-x64-musl/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-linux-x64-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-linux-x64-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-win32-arm64/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-win32-arm64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-win32-arm64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "win32"
   ],

--- a/npm/yuku-analyzer/@yuku-analyzer/binding-win32-x64/package.json
+++ b/npm/yuku-analyzer/@yuku-analyzer/binding-win32-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-analyzer/binding-win32-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "win32"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-darwin-arm64/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-darwin-arm64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-darwin-arm64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "darwin"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-darwin-x64/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-darwin-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-darwin-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "darwin"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-freebsd-x64/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-freebsd-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-freebsd-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "freebsd"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-linux-arm-gnu/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-linux-arm-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-linux-arm-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-linux-arm-musl/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-linux-arm-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-linux-arm-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-linux-arm64-gnu/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-linux-arm64-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-linux-arm64-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-linux-arm64-musl/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-linux-arm64-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-linux-arm64-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-linux-x64-gnu/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-linux-x64-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-linux-x64-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-linux-x64-musl/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-linux-x64-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-linux-x64-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-win32-arm64/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-win32-arm64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-win32-arm64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "win32"
   ],

--- a/npm/yuku-codegen/@yuku-codegen/binding-win32-x64/package.json
+++ b/npm/yuku-codegen/@yuku-codegen/binding-win32-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-codegen/binding-win32-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "win32"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-darwin-arm64/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-darwin-arm64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-darwin-arm64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "darwin"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-darwin-x64/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-darwin-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-darwin-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "darwin"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-freebsd-x64/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-freebsd-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-freebsd-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "freebsd"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-linux-arm-gnu/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-linux-arm-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-linux-arm-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-linux-arm-musl/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-linux-arm-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-linux-arm-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-linux-arm64-gnu/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-linux-arm64-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-linux-arm64-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-linux-arm64-musl/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-linux-arm64-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-linux-arm64-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-linux-x64-gnu/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-linux-x64-gnu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-linux-x64-gnu",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-linux-x64-musl/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-linux-x64-musl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-linux-x64-musl",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "linux"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-win32-arm64/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-win32-arm64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-win32-arm64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "win32"
   ],

--- a/npm/yuku-parser/@yuku-parser/binding-win32-x64/package.json
+++ b/npm/yuku-parser/@yuku-parser/binding-win32-x64/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuku-parser/binding-win32-x64",
   "version": "0.7.0",
+  "license": "MIT",
   "os": [
     "win32"
   ],


### PR DESCRIPTION
ref. https://github.com/yuku-toolchain/napi-zig/pull/13


Add `"license": "MIT"` to all 33 `@yuku-*/binding-*` package.json files.
Align binding package metadata with the main npm packages and the repository LICENSE