### PR TITLE
Bump napi-zig for android-arm64 bindings

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.3.0",
     .dependencies = .{
         .napi_zig = .{
-            .url = "git+https://github.com/yuku-toolchain/napi-zig?ref=HEAD#26920ed54b2bd1272bc61a896fe74acf5ab5bcd3",
-            .hash = "napi_zig-0.2.0-XRkY0ST4AQDNYESy6YfQKDwY2nfP6YIyMf0jQiGO3gCN",
+            .url = "git+https://github.com/yuku-toolchain/napi-zig?ref=HEAD#253f5a92b1c0c70ad13a6583993a9befb88d1116",
+            .hash = "napi_zig-0.2.0-XRkY0Y8XAgBr17lGjp5nFI-CYpmjGManq9S4TkaY-D5g",
         },
     },
     .fingerprint = 0xc32fad6e9edaaa9b, // Changing this has security and trust implications.


### PR DESCRIPTION
Follow-up to #146, now that yuku-toolchain/napi-zig#14 is merged: bumping napi-zig makes the release job also publish `@yuku-{parser,codegen,analyzer}/binding-android-arm64`. Nothing else to change: the JS loaders already compute the android-arm64 suffix at runtime, and napi-zig finds the runners' preinstalled Android NDK by itself.

## Validation

- Replayed the release build (`bun run build:npm`) on a stock ubuntu runner: https://github.com/dlecan/yuku/actions/runs/30701717495. The three android-arm64 bindings come out as aarch64 ELF.
- Termux device (aarch64, node 24): the three addons build and load against the bumped napi-zig.
