### PR TITLE
Complete generic dialect analysis and codegen seam

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -20,6 +20,18 @@ pub fn build(b: *std.Build) void {
     const codegen_options = b.addOptions();
     codegen_options.addOption(bool, "source_maps", enable_source_maps);
 
+    const dialect_abi_module = b.addModule("dialect-abi", .{
+        .root_source_file = b.path("src/parser/dialect/abi.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const none_dialect_module = b.createModule(.{
+        .root_source_file = b.path("src/parser/dialect/none.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    none_dialect_module.addImport("dialect_abi", dialect_abi_module);
+
     const parser_module = b.addModule("parser", .{
         .root_source_file = b.path("src/parser/root.zig"),
         .target = target,
@@ -28,6 +40,24 @@ pub fn build(b: *std.Build) void {
 
     parser_module.addImport("util", util_module);
     parser_module.addImport("codegen_options", codegen_options.createModule());
+    parser_module.addImport("dialect_abi", dialect_abi_module);
+    parser_module.addImport("dialect", none_dialect_module);
+
+    const dialect_parser_module = b.addModule("parser-dialect", .{
+        .root_source_file = b.path("src/parser/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    dialect_parser_module.addImport("util", util_module);
+    dialect_parser_module.addImport("codegen_options", codegen_options.createModule());
+    dialect_parser_module.addImport("dialect_abi", dialect_abi_module);
+
+    const dialect_transfer_module = b.addModule("transfer-dialect", .{
+        .root_source_file = b.path("src/parser/ffi/transfer/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    _ = dialect_transfer_module;
 
     const gen_unicode_id_table = b.addExecutable(.{
         .name = "gen-unicode-id",
@@ -84,6 +114,8 @@ pub fn build(b: *std.Build) void {
     });
     fuzz_parser.addImport("util", fuzz_util);
     fuzz_parser.addImport("codegen_options", codegen_options.createModule());
+    fuzz_parser.addImport("dialect_abi", dialect_abi_module);
+    fuzz_parser.addImport("dialect", none_dialect_module);
     const fuzz_driver = b.createModule(.{
         .root_source_file = b.path("src/parser/testing/fuzz/main.zig"),
         .target = b.graph.host,
@@ -211,6 +243,22 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     ast_transfer_module.addImport("parser", parser_module);
+
+    const dialect_capacity_module = b.createModule(.{
+        .root_source_file = b.path("src/parser/testing/dialect.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    dialect_capacity_module.addImport("parser", parser_module);
+    dialect_capacity_module.addImport("transfer", ast_transfer_module);
+    const dialect_capacity_tests = b.addRunArtifact(b.addTest(.{
+        .root_module = dialect_capacity_module,
+    }));
+    const dialect_capacity_step = b.step(
+        "test-dialect-capacity",
+        "Derive the base node and transfer capacity",
+    );
+    dialect_capacity_step.dependOn(&dialect_capacity_tests.step);
 
     inline for ([_]struct {
         step: []const u8,

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -7,6 +7,7 @@ const std = @import("std");
 const strings = @import("strings.zig");
 const TokenSpan = @import("token.zig").Span;
 const TokenTag = @import("token.zig").TokenTag;
+const dialect = @import("dialect");
 
 pub const String = strings.String;
 pub const StringPool = strings.ASTStringPool;
@@ -191,6 +192,7 @@ pub const Tree = struct {
     source_type: SourceType = .module,
     /// Language variant (js, ts, jsx, tsx, dts).
     lang: Lang = .js,
+    dialect_store: dialect.Store = .{},
 
     /// Creates a tree for parsing or transforming source code.
     pub fn init(child_allocator: std.mem.Allocator, source: []const u8) Tree {
@@ -216,6 +218,21 @@ pub const Tree = struct {
 
     pub inline fn allocator(self: *Tree) std.mem.Allocator {
         return self.arena.allocator();
+    }
+
+    pub fn addDialectRecord(self: *Tree, record: dialect.Record) !u32 {
+        if (comptime !dialect.enabled) unreachable;
+        return self.dialect_store.addRecord(self.allocator(), record);
+    }
+
+    pub fn addDialectOverlay(self: *Tree, host_node: u32, record_index: u32) !void {
+        if (comptime !dialect.enabled) unreachable;
+        return self.dialect_store.addOverlay(self.allocator(), host_node, record_index);
+    }
+
+    pub fn dialectOverlay(self: *const Tree, host_node: u32) ?u32 {
+        if (comptime !dialect.enabled) return null;
+        return self.dialect_store.findOverlay(host_node);
     }
 
     pub inline fn isTs(self: *const Tree) bool {
@@ -4029,6 +4046,10 @@ pub const JSXSpreadChild = struct {
     expression: NodeIndex,
 };
 
+pub const DialectNode = struct {
+    record_index: u32,
+};
+
 pub const NodeData = union(enum) {
     sequence_expression: SequenceExpression,
     parenthesized_expression: ParenthesizedExpression,
@@ -4205,6 +4226,7 @@ pub const NodeData = union(enum) {
     jsx_empty_expression: JSXEmptyExpression,
     jsx_text: JSXText,
     jsx_spread_child: JSXSpreadChild,
+    dialect_node: DialectNode,
 
     /// True when this node produces a value at runtime.
     ///

--- a/src/parser/codegen/printer.zig
+++ b/src/parser/codegen/printer.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const util = @import("util");
 const ast = @import("../ast.zig");
+const dialect = @import("dialect");
 const sourcemap = @import("sourcemap.zig");
 const utils = @import("utils.zig");
 
@@ -8,7 +9,7 @@ const source_maps = @import("codegen_options").source_maps;
 
 const Allocator = std.mem.Allocator;
 const Tree = ast.Tree;
-const NodeIndex = ast.NodeIndex;
+pub const NodeIndex = ast.NodeIndex;
 const NodeData = ast.NodeData;
 const IndexRange = ast.IndexRange;
 const Precedence = @import("../token.zig").Precedence;
@@ -152,6 +153,7 @@ const Printer = struct {
     in_prologue: bool = false,
     /// `in` forbidden in the current declarator init (a `for` head)
     decl_no_in: bool = false,
+    dialect_overlay: bool = true,
 
     fn init(allocator: Allocator, tree: *Tree, options: Options) Error!Self {
         var p = Self{
@@ -465,7 +467,25 @@ const Printer = struct {
         if (self.at_lead != .none) {
             switch (data) {
                 .object_expression => return true,
-                .assignment_expression => |a| if (self.nodeData(a.left) == .object_pattern) return true,
+                .assignment_expression => |a| if (self.nodeData(a.left) == .object_pattern) {
+                    if (comptime @hasDecl(dialect, "codegen")) {
+                        if (comptime @hasDecl(
+                            dialect.codegen,
+                            "hasDisambiguatingAssignmentTargetPrefix",
+                        )) {
+                            const target_raw: u32 = @intFromEnum(a.left);
+                            if (self.tree.dialectOverlay(target_raw)) |record_index| {
+                                if (dialect.codegen.hasDisambiguatingAssignmentTargetPrefix(
+                                    Self,
+                                    self,
+                                    record_index,
+                                    target_raw,
+                                )) return false;
+                            }
+                        }
+                    }
+                    return true;
+                },
                 else => {},
             }
         }
@@ -514,9 +534,21 @@ const Printer = struct {
     inline fn emitNode(self: *Self, idx: NodeIndex, ctx: Ctx) Error!void {
         if (comptime source_maps) if (self.sm != null) try self.recordMapping(idx);
 
+        if (comptime @hasDecl(dialect, "codegen")) if (self.dialect_overlay) {
+            if (self.tree.dialectOverlay(@intFromEnum(idx))) |record_index| {
+                if (try dialect.codegen.printOverlay(Self, self, record_index, idx)) return;
+            }
+        };
+
         switch (self.node_data[@intFromEnum(idx)]) {
             inline else => |*node, tag| {
-                if (comptime fixedString(tag)) |s| {
+                if (comptime tag == .dialect_node) {
+                    if (comptime @hasDecl(dialect, "codegen")) {
+                        try dialect.codegen.print(Self, self, node.record_index);
+                    } else {
+                        unreachable;
+                    }
+                } else if (comptime fixedString(tag)) |s| {
                     try self.writeStr(s);
                 } else {
                     const fn_name = "emit_" ++ @tagName(tag);
@@ -534,6 +566,79 @@ const Printer = struct {
                 }
             },
         }
+    }
+
+    pub fn dialectWrite(self: *Self, bytes: []const u8) Error!void {
+        std.debug.assert(bytes.len > 0);
+        const output_len = self.code.items.len;
+        try self.writeStr(bytes);
+        std.debug.assert(self.code.items.len > output_len);
+    }
+
+    pub fn dialectSpace(self: *Self) Error!void {
+        std.debug.assert(self.code.items.len > 0);
+        const output_len = self.code.items.len;
+        try self.space();
+        std.debug.assert(self.code.items.len >= output_len);
+    }
+
+    pub fn dialectEmit(self: *Self, raw: u32) Error!void {
+        std.debug.assert(raw < self.node_data.len);
+        const output_len = self.code.items.len;
+        try self.emit(@enumFromInt(raw));
+        std.debug.assert(self.code.items.len >= output_len);
+    }
+
+    pub fn dialectEmitStatements(self: *Self, start: u32, len: u32) Error!void {
+        std.debug.assert(start + len >= start);
+        std.debug.assert(start + len <= self.tree.extras.items.len);
+        const output_len = self.code.items.len;
+        for (self.tree.extras.items[start .. start + len], 0..) |node, index| {
+            std.debug.assert(@intFromEnum(node) < self.node_data.len);
+            if (index > 0) try self.space();
+            try self.emit(node);
+            try self.flushSemi();
+        }
+        std.debug.assert(self.code.items.len >= output_len);
+    }
+
+    pub fn dialectEmitOverlaySuppressed(self: *Self, raw: u32) Error!void {
+        std.debug.assert(raw < self.node_data.len);
+        const output_len = self.code.items.len;
+        const previous = self.dialect_overlay;
+        defer self.dialect_overlay = previous;
+        self.dialect_overlay = false;
+        try self.emitNode(@enumFromInt(raw), .{});
+        std.debug.assert(self.code.items.len >= output_len);
+    }
+
+    pub fn dialectEmitForLeft(self: *Self, raw: u32) Error!void {
+        std.debug.assert(raw < self.node_data.len);
+        const output_len = self.code.items.len;
+        try self.printForLeft(@enumFromInt(raw));
+        std.debug.assert(self.code.items.len >= output_len);
+    }
+
+    pub fn dialectEmitValue(self: *Self, raw: u32) Error!void {
+        std.debug.assert(raw < self.node_data.len);
+        const output_len = self.code.items.len;
+        try self.emitValue(@enumFromInt(raw));
+        std.debug.assert(self.code.items.len >= output_len);
+    }
+
+    pub fn dialectEmitStatement(self: *Self, raw: u32) Error!void {
+        std.debug.assert(raw < self.node_data.len);
+        const output_len = self.code.items.len;
+        try self.emitStmt(@enumFromInt(raw));
+        std.debug.assert(self.code.items.len >= output_len);
+    }
+
+    pub fn dialectEmitBlock(self: *Self, start: u32, len: u32) Error!void {
+        std.debug.assert(start + len >= start);
+        std.debug.assert(start + len <= self.tree.extras.items.len);
+        const output_len = self.code.items.len;
+        try self.printBlock(.{ .start = start, .len = len }, false);
+        std.debug.assert(self.code.items.len > output_len);
     }
 
     inline fn allowComment(self: *const Self, c: ast.AttachedComment) bool {
@@ -2826,7 +2931,11 @@ const Printer = struct {
     fn emit_jsx_empty_expression(_: *Self, _: *const ast.JSXEmptyExpression) Error!void {}
 
     fn emit_jsx_text(self: *Self, t: *const ast.JSXText) Error!void {
-        try self.writeString(t.value);
+        if (comptime @hasDecl(dialect, "codegen")) {
+            try dialect.codegen.printText(Self, self, self.tree.string(t.value));
+        } else {
+            try self.writeString(t.value);
+        }
     }
 
     fn emit_jsx_spread_child(self: *Self, c: *const ast.JSXSpreadChild) Error!void {

--- a/src/parser/dialect/abi.zig
+++ b/src/parser/dialect/abi.zig
@@ -33,7 +33,17 @@ pub const Hook = enum(u8) {
 
 /// Dependency-free reflected field roles. Dialect schemas use these wrappers
 /// instead of borrowing parser AST types or relying on field-name conventions.
-pub const FieldRole = enum { scalar_u32, node_ref, optional_node_ref, node_list, string_slice, overlay_host };
+pub const FieldRole = enum(u8) {
+    scalar_u32,
+    node_ref,
+    optional_node_ref,
+    node_list,
+    string_slice,
+    overlay_host,
+};
+
+/// Dialect-neutral lexical behavior attached to reflected record payloads.
+pub const ScopeRole = enum(u8) { none, block };
 
 fn Word(comptime role: FieldRole) type {
     return packed struct(u32) {
@@ -63,4 +73,8 @@ pub const StringSlice = extern struct {
 comptime {
     std.debug.assert(@typeInfo(Hook).@"enum".fields.len == 19);
     std.debug.assert(@sizeOf(Hook) == 1);
+    std.debug.assert(@typeInfo(FieldRole).@"enum".fields.len == 6);
+    std.debug.assert(@sizeOf(FieldRole) == 1);
+    std.debug.assert(@typeInfo(ScopeRole).@"enum".fields.len == 2);
+    std.debug.assert(@sizeOf(ScopeRole) == 1);
 }

--- a/src/parser/dialect/abi.zig
+++ b/src/parser/dialect/abi.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+
+pub fn Decision(comptime T: type) type {
+    std.debug.assert(@sizeOf(T) <= @sizeOf(u64));
+    std.debug.assert(@alignOf(T) <= @alignOf(u64));
+    return union(enum) {
+        unhandled,
+        handled: T,
+    };
+}
+
+pub const Hook = enum(u8) {
+    statement_at_code_block,
+    statement_at_control_flow,
+    expression_at_code_block,
+    expression_at_control_flow,
+    lazy_assignment_pattern,
+    function_body_starts,
+    function_body,
+    for_of_tail,
+    binding_pattern,
+    module_specifier,
+    can_start_binding,
+    jsx_element_after_open,
+    jsx_names_match,
+    jsx_text_boundary,
+    jsx_text_value,
+    jsx_child_at_code_block,
+    jsx_child_at_control_flow,
+    jsx_element_name,
+    validate_jsx_element_name,
+};
+
+/// Dependency-free reflected field roles. Dialect schemas use these wrappers
+/// instead of borrowing parser AST types or relying on field-name conventions.
+pub const FieldRole = enum { scalar_u32, node_ref, optional_node_ref, node_list, string_slice, overlay_host };
+
+fn Word(comptime role: FieldRole) type {
+    return packed struct(u32) {
+        raw: u32,
+        pub const dialect_role = role;
+        pub inline fn init(value: u32) @This() {
+            return .{ .raw = value };
+        }
+    };
+}
+
+pub const ScalarU32 = Word(.scalar_u32);
+pub const NodeRef = Word(.node_ref);
+pub const OptionalNodeRef = Word(.optional_node_ref);
+pub const OverlayHost = Word(.overlay_host);
+pub const NodeList = extern struct {
+    start: u32,
+    len: u32,
+    pub const dialect_role = FieldRole.node_list;
+};
+pub const StringSlice = extern struct {
+    start: u32,
+    end: u32,
+    pub const dialect_role = FieldRole.string_slice;
+};
+
+comptime {
+    std.debug.assert(@typeInfo(Hook).@"enum".fields.len == 19);
+    std.debug.assert(@sizeOf(Hook) == 1);
+}

--- a/src/parser/dialect/none.zig
+++ b/src/parser/dialect/none.zig
@@ -1,0 +1,15 @@
+const abi = @import("dialect_abi");
+
+pub const enabled = false;
+pub const hooks = [_]abi.Hook{};
+pub const Record = struct {};
+pub const Store = struct {};
+pub const schema = struct {
+    pub const record_count: u8 = 0;
+    pub const Record = struct {};
+};
+
+comptime {
+    if (enabled) @compileError("the disabled dialect cannot enable hooks");
+    if (hooks.len != 0) @compileError("the disabled dialect cannot declare hooks");
+}

--- a/src/parser/dialect/none.zig
+++ b/src/parser/dialect/none.zig
@@ -2,7 +2,7 @@ const abi = @import("dialect_abi");
 
 pub const enabled = false;
 pub const hooks = [_]abi.Hook{};
-pub const Record = struct {};
+pub const Record = schema.Record;
 pub const Store = struct {};
 pub const schema = struct {
     pub const record_count: u8 = 0;

--- a/src/parser/ffi/parser.zig
+++ b/src/parser/ffi/parser.zig
@@ -9,6 +9,7 @@ const Options = struct {
     preserve_parens: bool = true,
     semantic_errors: bool = false,
     attach_comments: bool = false,
+    loose: bool = false,
 };
 
 pub fn parse(env: napi.Env, source: []const u8, options: Options) !napi.Val {
@@ -17,6 +18,7 @@ pub fn parse(env: napi.Env, source: []const u8, options: Options) !napi.Val {
         .lang = options.lang,
         .preserve_parens = options.preserve_parens,
         .comments = if (options.attach_comments) .both else .flat,
+        .loose = options.loose,
     }) catch return error.ParseFailed;
     defer tree.deinit();
 

--- a/src/parser/ffi/transfer/root.zig
+++ b/src/parser/ffi/transfer/root.zig
@@ -107,7 +107,8 @@
 //       n bytes   message text (UTF-8)
 
 const std = @import("std");
-const ast = @import("parser").ast;
+const parser = @import("parser");
+const ast = parser.ast;
 
 /// The analyzer's semantic sections, layered on this format. Exposed
 /// here so the decoder generators reach both layouts through one module.
@@ -144,7 +145,7 @@ const Header = extern struct {
 /// any further IndexRange uses two consecutive u32 slots, start then
 /// length (no current node needs a third). the comptime validator
 /// enforces the 7 slot and 16 flag bit budget regardless.
-const PackedNode = extern struct {
+pub const PackedNode = extern struct {
     tag: u8,
     _pad0: u8 = 0,
     flags: u16,
@@ -219,6 +220,11 @@ pub const FLAG_COMMENTS: u32 = 1 << 2;
 /// consumed only by the analyzer decoder. Other decoders never read
 /// past diagnostics, so the bit is invisible to them.
 pub const FLAG_SEMANTIC: u32 = 1 << 3;
+/// Optional reflected dialect records and overlays, immediately before diagnostics.
+/// Empty stores omit both this flag and the section, preserving the v7 control bytes.
+pub const FLAG_DIALECT_RECORDS: u32 = 1 << 4;
+pub const DIALECT_SUBHEADER_SIZE: usize = 8;
+pub const DIALECT_OVERLAY_SIZE: usize = 8;
 
 // `PackedNode` byte offsets and u32 indices.
 pub const NODE_FLAGS_OFFSET: u8 = @offsetOf(PackedNode, "flags");
@@ -256,6 +262,8 @@ comptime {
 /// number of flag bits consumed by field `field_idx` in struct T.
 pub fn flagBitCount(comptime T: type, comptime field_idx: usize) u8 {
     const f = std.meta.fields(T)[field_idx];
+    if (comptime isDialectRoleType(f.type)) return 0;
+    if (f.type == u32) return 0;
     if (f.type == bool) return 1;
     if (f.type == ?ast.ImportPhase) return 1 + enumBitWidth(ast.ImportPhase);
     if (f.type == ?ast.Hashbang) return 1;
@@ -267,6 +275,7 @@ pub fn flagBitCount(comptime T: type, comptime field_idx: usize) u8 {
 /// starting flag bit position for field `target` in struct T.
 pub fn flagBitForField(comptime T: type, comptime target: usize) u8 {
     comptime {
+        @setEvalBranchQuota(20_000);
         var bit: u8 = 0;
         for (0..target) |i| bit += flagBitCount(T, i);
         return bit;
@@ -278,6 +287,8 @@ pub fn flagBitForField(comptime T: type, comptime target: usize) u8 {
 /// length fields (`field0`, `field0b`), so they take one slot each.
 pub fn fieldU32Count(comptime T: type, comptime field_idx: usize) u8 {
     const f = std.meta.fields(T)[field_idx];
+    if (comptime isDialectRoleType(f.type)) return if (@sizeOf(f.type) == 8) 2 else 1;
+    if (f.type == u32) return 1;
     if (f.type == ast.NodeIndex) return 1;
     if (f.type == ast.IndexRange) return if (rangeIndexOf(T, field_idx) < 2) 1 else 2;
     if (f.type == ast.String) return 2;
@@ -289,6 +300,7 @@ pub fn fieldU32Count(comptime T: type, comptime field_idx: usize) u8 {
 /// first u32 slot index for field `target` in struct T.
 pub fn u32SlotForField(comptime T: type, comptime target: usize) u8 {
     comptime {
+        @setEvalBranchQuota(20_000);
         var slot: u8 = 0;
         for (0..target) |i| slot += fieldU32Count(T, i);
         return slot;
@@ -315,6 +327,13 @@ pub fn enumBitWidth(comptime E: type) u8 {
 
 pub fn isEnumType(comptime T: type) bool {
     return @typeInfo(T) == .@"enum";
+}
+
+pub fn isDialectRoleType(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .@"struct" => @hasDecl(T, "dialect_role"),
+        else => false,
+    };
 }
 
 /// total u32 slots used by struct T.
@@ -377,6 +396,14 @@ pub fn bufferSize(tree: *const ast.Tree) usize {
         tree.attached_comments.len * ATTACHED_COMMENT_SIZE +
         tree.comments.len * COMMENT_SIZE;
 
+    if (comptime parser.dialect_enabled) {
+        if (tree.dialect_store.records.items.len != 0 or tree.dialect_store.overlays.items.len != 0) {
+            size += DIALECT_SUBHEADER_SIZE +
+                tree.dialect_store.records.items.len * NODE_SIZE +
+                tree.dialect_store.overlays.items.len * DIALECT_OVERLAY_SIZE;
+        }
+    }
+
     for (tree.diagnostics.items) |d| {
         size += diag_fixed + d.message.len;
         if (d.help) |h| size += help_prefix + h.len;
@@ -402,6 +429,10 @@ pub fn serializeInto(tree: *const ast.Tree, buf: []u8) usize {
     if (tree.isTs()) hdr_flags |= FLAG_TS;
     if (has_attached) hdr_flags |= FLAG_ATTACHED_COMMENTS;
     if (has_comments) hdr_flags |= FLAG_COMMENTS;
+    if (comptime parser.dialect_enabled) {
+        if (tree.dialect_store.records.items.len != 0 or tree.dialect_store.overlays.items.len != 0)
+            hdr_flags |= FLAG_DIALECT_RECORDS;
+    }
 
     const hdr = Header{
         .node_count = @intCast(tree.nodes.len),
@@ -471,6 +502,25 @@ pub fn serializeInto(tree: *const ast.Tree, buf: []u8) usize {
     }
     pos += tree.comments.len * COMMENT_SIZE;
 
+    // Optional generic dialect store. Records use the exact PackedNode ABI and
+    // overlays are sorted host/index u32 pairs.
+    if (hdr_flags & FLAG_DIALECT_RECORDS != 0) {
+        if (comptime !parser.dialect_enabled) unreachable;
+        w32(buf, pos, @intCast(tree.dialect_store.records.items.len));
+        w32(buf, pos + 4, @intCast(tree.dialect_store.overlays.items.len));
+        pos += DIALECT_SUBHEADER_SIZE;
+        const records_out: [*]PackedNode = @ptrCast(@alignCast(buf.ptr + pos));
+        for (tree.dialect_store.records.items, 0..) |*record, i| {
+            records_out[i] = packDialectRecord(record) catch unreachable;
+        }
+        pos += tree.dialect_store.records.items.len * NODE_SIZE;
+        for (tree.dialect_store.overlays.items) |overlay| {
+            w32(buf, pos, overlay.host_node);
+            w32(buf, pos + 4, overlay.record_index);
+            pos += DIALECT_OVERLAY_SIZE;
+        }
+    }
+
     // diagnostics (variable length)
     for (tree.diagnostics.items) |d| {
         buf[pos] = @intFromEnum(d.severity);
@@ -538,10 +588,20 @@ fn packPayload(n: *PackedNode, payload: anytype) void {
         const bit = comptime flagBitForField(T, i);
         const slot = comptime u32SlotForField(T, i);
 
-        if (f.type == bool) {
+        if (comptime isDialectRoleType(f.type)) {
+            switch (comptime f.type.dialect_role) {
+                .node_list, .string_slice => {
+                    setSlot(n, slot, val.start);
+                    setSlot(n, slot + 1, if (f.type.dialect_role == .node_list) val.len else val.end);
+                },
+                else => setSlot(n, slot, val.raw),
+            }
+        } else if (f.type == bool) {
             if (val) setFlagBit(n, bit);
         } else if (f.type == ast.NodeIndex) {
             setSlot(n, slot, @intFromEnum(val));
+        } else if (f.type == u32) {
+            setSlot(n, slot, val);
         } else if (f.type == ast.IndexRange) {
             switch (comptime rangeIndexOf(T, i)) {
                 0 => n.field0 = @intCast(val.len),
@@ -570,6 +630,52 @@ fn packPayload(n: *PackedNode, payload: anytype) void {
                 "' in " ++ @typeName(T));
         }
     }
+}
+
+pub const DialectRecordError = error{ InvalidDialectTag, DialectDisabled };
+
+pub fn packDialectRecord(record: *const parser.dialect_schema.Record) DialectRecordError!PackedNode {
+    if (comptime !parser.dialect_enabled) return error.DialectDisabled;
+    var packed_record = std.mem.zeroes(PackedNode);
+    switch (record.*) {
+        inline else => |*payload, schema_tag| {
+            const base_tag = comptime dialectNodeTag() + 1;
+            const tag = base_tag + @intFromEnum(schema_tag);
+            if (tag > std.math.maxInt(u8)) return error.InvalidDialectTag;
+            packed_record.tag = @intCast(tag);
+            packPayload(&packed_record, payload);
+        },
+    }
+    return packed_record;
+}
+
+pub fn unpackDialectRecord(packed_record: PackedNode) DialectRecordError!parser.dialect_schema.Record {
+    if (comptime !parser.dialect_enabled) return error.DialectDisabled;
+    const base_tag = comptime dialectNodeTag() + 1;
+    inline for (@typeInfo(parser.dialect_schema.Record).@"union".fields, 0..) |field, index| {
+        if (packed_record.tag == base_tag + index) {
+            var payload: field.type = std.mem.zeroes(field.type);
+            unpackPayload(field.type, packed_record, &payload);
+            return @unionInit(parser.dialect_schema.Record, field.name, payload);
+        }
+    }
+    return error.InvalidDialectTag;
+}
+
+pub fn dialectNodeTag() u8 {
+    const fields = @typeInfo(ast.NodeData).@"union".fields;
+    if (comptime fields.len == 0) @compileError("NodeData must be nonempty");
+    const final_index = comptime fields.len - 1;
+    const final_field = comptime fields[final_index];
+    if (comptime !std.mem.eql(u8, final_field.name, "dialect_node"))
+        @compileError("NodeData must contain dialect_node as its appended final variant");
+    const Tag = std.meta.Tag(ast.NodeData);
+    const reflected_tag = comptime @intFromEnum(@field(Tag, final_field.name));
+    if (comptime reflected_tag != final_index)
+        @compileError("dialect_node tag must equal its reflected final field index");
+    if (comptime reflected_tag > std.math.maxInt(u8))
+        @compileError("dialect_node tag exceeds the transfer tag capacity");
+    return @intCast(reflected_tag);
 }
 
 inline fn setFlagBit(n: *PackedNode, comptime bit: u8) void {
@@ -628,8 +734,10 @@ pub fn deserializeFromBuf(
     // header sanity: the program index must point inside the node array.
     // source may be empty (then every `String` resolves via the pool) or
     // match `hdr.source_len` for direct slicing.
-    std.debug.assert(source.len == 0 or source.len == hdr.source_len);
-    std.debug.assert(hdr.program_index < hdr.node_count);
+    if (source.len != 0 and source.len != hdr.source_len) return error.InvalidBuffer;
+    if (hdr.program_index >= hdr.node_count) return error.InvalidBuffer;
+    if (hdr.flags & FLAG_DIALECT_RECORDS != 0 and comptime !parser.dialect_enabled)
+        return error.InvalidBuffer;
 
     var tree = ast.Tree.init(allocator, source);
     errdefer tree.deinit();
@@ -646,7 +754,7 @@ pub fn deserializeFromBuf(
     for (0..hdr.node_count) |i| {
         const pn = nodes_in[i];
         tree.nodes.set(i, .{
-            .data = unpackNode(pn),
+            .data = unpackNode(pn) orelse return error.InvalidBuffer,
             .span = .{ .start = pn.span_start, .end = pn.span_end },
         });
     }
@@ -715,6 +823,39 @@ pub fn deserializeFromBuf(
     }
     pos += comments_bytes;
 
+    if (hdr.flags & FLAG_DIALECT_RECORDS != 0) {
+        if (buf.len - pos < DIALECT_SUBHEADER_SIZE) return error.InvalidBuffer;
+        const record_count = std.mem.readInt(u32, buf[pos..][0..4], .little);
+        const overlay_count = std.mem.readInt(u32, buf[pos + 4 ..][0..4], .little);
+        if (record_count == 0) return error.InvalidBuffer;
+        pos += DIALECT_SUBHEADER_SIZE;
+        const record_bytes = std.math.mul(usize, record_count, NODE_SIZE) catch return error.InvalidBuffer;
+        const overlay_bytes = std.math.mul(usize, overlay_count, DIALECT_OVERLAY_SIZE) catch return error.InvalidBuffer;
+        if (record_bytes > buf.len - pos) return error.InvalidBuffer;
+        const records_in: [*]const PackedNode = @ptrCast(@alignCast(buf.ptr + pos));
+        for (0..record_count) |i| {
+            const record = unpackDialectRecord(records_in[i]) catch return error.InvalidBuffer;
+            _ = tree.addDialectRecord(record) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return error.InvalidBuffer,
+            };
+        }
+        pos += record_bytes;
+        if (overlay_bytes > buf.len - pos) return error.InvalidBuffer;
+        for (0..overlay_count) |_| {
+            const host = std.mem.readInt(u32, buf[pos..][0..4], .little);
+            const record = std.mem.readInt(u32, buf[pos + 4 ..][0..4], .little);
+            if (host >= hdr.node_count or record >= record_count) return error.InvalidBuffer;
+            tree.addDialectOverlay(host, record) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return error.InvalidBuffer,
+            };
+            pos += DIALECT_OVERLAY_SIZE;
+        }
+    }
+
+    try validateDialectStore(&tree, hdr.source_len);
+
     // skip diagnostics. codegen doesn't read them.
 
     tree.root = @enumFromInt(hdr.program_index);
@@ -722,7 +863,126 @@ pub fn deserializeFromBuf(
     return tree;
 }
 
-fn unpackNode(p: PackedNode) ast.NodeData {
+fn validateDialectStore(tree: *ast.Tree, source_len: u32) DeserializeError!void {
+    if (comptime !parser.dialect_enabled) return;
+    const records = tree.dialect_store.records.items;
+    for (records) |*record| {
+        if (!validateDialectFields(tree, source_len, record)) return error.InvalidBuffer;
+    }
+    for (tree.nodes.items(.data)) |data| {
+        if (data != .dialect_node) continue;
+        const ri = data.dialect_node.record_index;
+        if (ri >= records.len or recordIsOverlay(&records[ri])) return error.InvalidBuffer;
+    }
+    for (tree.dialect_store.overlays.items) |overlay| {
+        if (overlay.host_node >= tree.nodes.len or overlay.record_index >= records.len)
+            return error.InvalidBuffer;
+        const record = &records[overlay.record_index];
+        if (!recordIsOverlay(record)) return error.InvalidBuffer;
+        if (recordOverlayHost(record) != overlay.host_node) return error.InvalidBuffer;
+    }
+    const states = try tree.allocator().alloc(u8, records.len);
+    @memset(states, 0);
+    for (0..records.len) |index| {
+        if (!visitDialectRecord(tree, @intCast(index), states)) return error.InvalidBuffer;
+    }
+}
+
+fn recordIsOverlay(record: *const parser.dialect_schema.Record) bool {
+    switch (record.*) {
+        inline else => |payload| {
+            inline for (std.meta.fields(@TypeOf(payload))) |field| {
+                if (comptime isDialectRoleType(field.type) and field.type.dialect_role == .overlay_host) return true;
+            }
+        },
+    }
+    return false;
+}
+
+fn recordOverlayHost(record: *const parser.dialect_schema.Record) ?u32 {
+    switch (record.*) {
+        inline else => |payload| {
+            inline for (std.meta.fields(@TypeOf(payload))) |field| {
+                if (comptime isDialectRoleType(field.type) and field.type.dialect_role == .overlay_host)
+                    return @field(payload, field.name).raw;
+            }
+        },
+    }
+    return null;
+}
+
+fn validateDialectFields(tree: *const ast.Tree, source_len: u32, record: *const parser.dialect_schema.Record) bool {
+    switch (record.*) {
+        inline else => |payload| {
+            inline for (std.meta.fields(@TypeOf(payload))) |field| {
+                if (comptime !isDialectRoleType(field.type)) continue;
+                const value = @field(payload, field.name);
+                switch (comptime field.type.dialect_role) {
+                    .scalar_u32 => {},
+                    .node_ref, .overlay_host => if (value.raw >= tree.nodes.len) return false,
+                    .optional_node_ref => if (value.raw != std.math.maxInt(u32) and value.raw >= tree.nodes.len) return false,
+                    .node_list => {
+                        const end = std.math.add(u32, value.start, value.len) catch return false;
+                        if (end > tree.extras.items.len) return false;
+                        for (tree.extras.items[value.start..end]) |node_index| {
+                            if (@intFromEnum(node_index) >= tree.nodes.len) return false;
+                        }
+                    },
+                    .string_slice => {
+                        if (value.start > value.end) return false;
+                        if (value.start < source_len) {
+                            if (value.end > source_len) return false;
+                        } else {
+                            const pool_end = std.math.add(u32, source_len, @intCast(tree.strings.extra.items.len)) catch return false;
+                            if (value.end > pool_end) return false;
+                        }
+                    },
+                }
+            }
+        },
+    }
+    return true;
+}
+
+fn visitDialectRecord(tree: *const ast.Tree, record_index: u32, states: []u8) bool {
+    if (record_index >= states.len) return false;
+    if (states[record_index] == 1) return false;
+    if (states[record_index] == 2) return true;
+    states[record_index] = 1;
+    const record = &tree.dialect_store.records.items[record_index];
+    switch (record.*) {
+        inline else => |payload| {
+            inline for (std.meta.fields(@TypeOf(payload))) |field| {
+                if (comptime !isDialectRoleType(field.type)) continue;
+                const value = @field(payload, field.name);
+                switch (comptime field.type.dialect_role) {
+                    .node_ref => if (!visitDialectNode(tree, value.raw, states)) return false,
+                    .optional_node_ref => if (value.raw != std.math.maxInt(u32) and !visitDialectNode(tree, value.raw, states)) return false,
+                    .node_list => {
+                        const end = value.start + value.len;
+                        for (tree.extras.items[value.start..end]) |node_index| {
+                            if (!visitDialectNode(tree, @intFromEnum(node_index), states)) return false;
+                        }
+                    },
+                    else => {},
+                }
+            }
+        },
+    }
+    states[record_index] = 2;
+    return true;
+}
+
+fn visitDialectNode(tree: *const ast.Tree, node_index: u32, states: []u8) bool {
+    if (node_index >= tree.nodes.len) return false;
+    const data = tree.nodes.items(.data)[node_index];
+    return if (data == .dialect_node)
+        visitDialectRecord(tree, data.dialect_node.record_index, states)
+    else
+        true;
+}
+
+fn unpackNode(p: PackedNode) ?ast.NodeData {
     @setEvalBranchQuota(100_000);
     inline for (@typeInfo(ast.NodeData).@"union".fields, 0..) |field, tag| {
         if (p.tag == tag) {
@@ -732,7 +992,7 @@ fn unpackNode(p: PackedNode) ast.NodeData {
             return @unionInit(ast.NodeData, field.name, payload);
         }
     }
-    unreachable;
+    return null;
 }
 
 fn unpackPayload(comptime T: type, n: PackedNode, payload: *T) void {
@@ -743,10 +1003,18 @@ fn unpackPayload(comptime T: type, n: PackedNode, payload: *T) void {
         const bit = comptime flagBitForField(T, i);
         const slot = comptime u32SlotForField(T, i);
 
-        if (f.type == bool) {
+        if (comptime isDialectRoleType(f.type)) {
+            switch (comptime f.type.dialect_role) {
+                .node_list => @field(payload.*, f.name) = .{ .start = readSlot(n, slot), .len = readSlot(n, slot + 1) },
+                .string_slice => @field(payload.*, f.name) = .{ .start = readSlot(n, slot), .end = readSlot(n, slot + 1) },
+                else => @field(payload.*, f.name) = .{ .raw = readSlot(n, slot) },
+            }
+        } else if (f.type == bool) {
             @field(payload.*, f.name) = readFlagBit(n, bit);
         } else if (f.type == ast.NodeIndex) {
             @field(payload.*, f.name) = @enumFromInt(readSlot(n, slot));
+        } else if (f.type == u32) {
+            @field(payload.*, f.name) = readSlot(n, slot);
         } else if (f.type == ast.IndexRange) {
             const len: u32 = switch (comptime rangeIndexOf(T, i)) {
                 0 => n.field0,

--- a/src/parser/ffi/transfer/root.zig
+++ b/src/parser/ffi/transfer/root.zig
@@ -409,7 +409,7 @@ pub fn bufferSize(tree: *const ast.Tree) usize {
         if (d.help) |h| size += help_prefix + h.len;
         for (d.labels) |lbl| size += label_fixed + lbl.message.len;
     }
-    return size;
+    return alignPool(size);
 }
 
 pub fn serializeInto(tree: *const ast.Tree, buf: []u8) usize {
@@ -557,6 +557,10 @@ pub fn serializeInto(tree: *const ast.Tree, buf: []u8) usize {
             pos += lbl.message.len;
         }
     }
+
+    const tail_pad = alignPool(pos) - pos;
+    @memset(buf[pos..][0..tail_pad], 0);
+    pos += tail_pad;
 
     // serializer must have written exactly the size reported by `bufferSize`
     std.debug.assert(pos == bufferSize(tree));

--- a/src/parser/lexer.zig
+++ b/src/parser/lexer.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const dialect = @import("dialect");
 const Token = @import("token.zig").Token;
 const TokenTag = @import("token.zig").TokenTag;
 const Span = @import("token.zig").Span;
@@ -6,6 +7,8 @@ const TokenFlag = @import("token.zig").TokenFlag;
 const flagMask = @import("token.zig").flagMask;
 const ast = @import("ast.zig");
 const util = @import("util");
+
+const DialectHost = struct {};
 
 pub const LexicalError = error{
     UnterminatedString,
@@ -453,6 +456,15 @@ pub const Lexer = struct {
 
         while (self.cursor < self.source.len) {
             const c = self.source[self.cursor];
+
+            if (c == '@') {
+                if (comptime dialect.enabled and @hasDecl(dialect, "jsx_text_boundary")) {
+                    switch (dialect.jsx_text_boundary(DialectHost, self.source, self.cursor)) {
+                        .handled => |is_boundary| if (is_boundary) break,
+                        .unhandled => {},
+                    }
+                }
+            }
 
             switch (c) {
                 '<', '{', '>', '}' => break,
@@ -1011,36 +1023,35 @@ pub const Lexer = struct {
     }
 
     const keyword_list = [_]struct { []const u8, TokenTag }{
-        .{ "if", .@"if" },          .{ "of", .of },             .{ "in", .in },
-        .{ "do", .do },             .{ "as", .as },             .{ "is", .is },
-        .{ "any", .any },           .{ "for", .@"for" },        .{ "get", .get },
-        .{ "let", .let },           .{ "new", .new },           .{ "out", .out },
-        .{ "set", .set },           .{ "try", .@"try" },        .{ "var", .@"var" },
-        .{ "case", .case },         .{ "this", .this },         .{ "else", .@"else" },
-        .{ "enum", .@"enum" },      .{ "void", .void },         .{ "with", .with },
-        .{ "null", .null_literal }, .{ "type", .type },         .{ "true", .true },
-        .{ "from", .from },         .{ "await", .await },       .{ "async", .async },
-        .{ "break", .@"break" },    .{ "const", .@"const" },    .{ "class", .class },
-        .{ "catch", .@"catch" },    .{ "defer", .@"defer" },    .{ "false", .false },
-        .{ "infer", .infer },       .{ "keyof", .keyof },       .{ "never", .never },
-        .{ "super", .super },       .{ "throw", .throw },       .{ "using", .using },
-        .{ "while", .@"while" },    .{ "yield", .yield },       .{ "assert", .assert },
-        .{ "bigint", .bigint },     .{ "delete", .delete },     .{ "export", .@"export" },
-        .{ "global", .global },     .{ "import", .import },     .{ "module", .module },
-        .{ "number", .number },     .{ "object", .object },     .{ "public", .public },
-        .{ "return", .@"return" },  .{ "string", .string },     .{ "symbol", .symbol },
-        .{ "switch", .@"switch" },  .{ "static", .static },     .{ "source", .source },
-        .{ "typeof", .typeof },     .{ "unique", .unique },     .{ "asserts", .asserts },
-        .{ "boolean", .boolean },   .{ "default", .default },   .{ "declare", .declare },
-        .{ "extends", .extends },   .{ "finally", .finally },   .{ "private", .private },
-        .{ "package", .package },   .{ "require", .require },   .{ "unknown", .unknown },
-        .{ "accessor", .accessor }, .{ "abstract", .abstract }, .{ "continue", .@"continue" },
-        .{ "debugger", .debugger }, .{ "function", .function }, .{ "override", .override },
-        .{ "readonly", .readonly }, .{ "interface", .interface },
-        .{ "intrinsic", .intrinsic },   .{ "namespace", .namespace },
-        .{ "protected", .protected },   .{ "satisfies", .satisfies },
-        .{ "undefined", .undefined },   .{ "instanceof", .instanceof },
-        .{ "implements", .implements }, .{ "constructor", .constructor },
+        .{ "if", .@"if" },                .{ "of", .of },                 .{ "in", .in },
+        .{ "do", .do },                   .{ "as", .as },                 .{ "is", .is },
+        .{ "any", .any },                 .{ "for", .@"for" },            .{ "get", .get },
+        .{ "let", .let },                 .{ "new", .new },               .{ "out", .out },
+        .{ "set", .set },                 .{ "try", .@"try" },            .{ "var", .@"var" },
+        .{ "case", .case },               .{ "this", .this },             .{ "else", .@"else" },
+        .{ "enum", .@"enum" },            .{ "void", .void },             .{ "with", .with },
+        .{ "null", .null_literal },       .{ "type", .type },             .{ "true", .true },
+        .{ "from", .from },               .{ "await", .await },           .{ "async", .async },
+        .{ "break", .@"break" },          .{ "const", .@"const" },        .{ "class", .class },
+        .{ "catch", .@"catch" },          .{ "defer", .@"defer" },        .{ "false", .false },
+        .{ "infer", .infer },             .{ "keyof", .keyof },           .{ "never", .never },
+        .{ "super", .super },             .{ "throw", .throw },           .{ "using", .using },
+        .{ "while", .@"while" },          .{ "yield", .yield },           .{ "assert", .assert },
+        .{ "bigint", .bigint },           .{ "delete", .delete },         .{ "export", .@"export" },
+        .{ "global", .global },           .{ "import", .import },         .{ "module", .module },
+        .{ "number", .number },           .{ "object", .object },         .{ "public", .public },
+        .{ "return", .@"return" },        .{ "string", .string },         .{ "symbol", .symbol },
+        .{ "switch", .@"switch" },        .{ "static", .static },         .{ "source", .source },
+        .{ "typeof", .typeof },           .{ "unique", .unique },         .{ "asserts", .asserts },
+        .{ "boolean", .boolean },         .{ "default", .default },       .{ "declare", .declare },
+        .{ "extends", .extends },         .{ "finally", .finally },       .{ "private", .private },
+        .{ "package", .package },         .{ "require", .require },       .{ "unknown", .unknown },
+        .{ "accessor", .accessor },       .{ "abstract", .abstract },     .{ "continue", .@"continue" },
+        .{ "debugger", .debugger },       .{ "function", .function },     .{ "override", .override },
+        .{ "readonly", .readonly },       .{ "interface", .interface },   .{ "intrinsic", .intrinsic },
+        .{ "namespace", .namespace },     .{ "protected", .protected },   .{ "satisfies", .satisfies },
+        .{ "undefined", .undefined },     .{ "instanceof", .instanceof }, .{ "implements", .implements },
+        .{ "constructor", .constructor },
     };
 
     const keyword_length_min = 2;

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -4,6 +4,13 @@ const TokenTag = @import("token.zig").TokenTag;
 const lexer = @import("lexer.zig");
 const ast = @import("ast.zig");
 const util = @import("util");
+const dialect = @import("dialect");
+
+comptime {
+    if (dialect.enabled and @hasDecl(dialect, "parse")) {
+        @compileError("external dialect contract forbids a second parser declaration");
+    }
+}
 
 const statements = @import("syntax/statements.zig");
 const comments = @import("comments.zig");
@@ -138,6 +145,25 @@ pub const Parser = struct {
 
     pub inline fn allocator(self: *Parser) std.mem.Allocator {
         return self.tree.allocator();
+    }
+
+    pub fn addDialectNode(
+        self: *Parser,
+        record: dialect.Record,
+        span: ast.Span,
+    ) Error!ast.NodeIndex {
+        const record_index = self.tree.addDialectRecord(record) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+        return self.tree.addNode(.{ .dialect_node = .{ .record_index = record_index } }, span);
+    }
+
+    pub fn parseDialectBlockWithTemporaryReturn(
+        self: *Parser,
+        allow_return: bool,
+    ) Error!?ast.NodeIndex {
+        return statements.parseBlockStatementWithTemporaryReturn(self, allow_return);
     }
 
     pub fn parse(self: *Parser) Error!ast.Tree {

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -50,6 +50,8 @@ pub const Options = struct {
     /// Whether and how comments are collected. Defaults to `.flat`: comments
     /// land in the flat `tree.comments` list with no per-node attachment.
     comments: CommentMode = .flat,
+    /// When true, recover nested JSX elements closed by an ancestor tag.
+    loose: bool = false,
 };
 
 pub const Context = packed struct {
@@ -104,6 +106,7 @@ pub const Parser = struct {
     lang: ast.Lang,
     preserve_parens: bool,
     comment_mode: CommentMode,
+    loose: bool,
     lexer: lexer.Lexer,
     diagnostics: std.ArrayList(ast.Diagnostic) = .empty,
 
@@ -138,6 +141,7 @@ pub const Parser = struct {
             .lang = options.lang,
             .preserve_parens = options.preserve_parens,
             .comment_mode = options.comments,
+            .loose = options.loose,
             .lexer = undefined,
             .current_token = Token.eof(0),
         };

--- a/src/parser/root.zig
+++ b/src/parser/root.zig
@@ -1,4 +1,5 @@
 const parser = @import("parser.zig");
+const dialect = @import("dialect");
 
 pub const parse = parser.parse;
 pub const Options = parser.Options;
@@ -9,6 +10,8 @@ pub const ast = @import("ast.zig");
 pub const traverser = @import("traverser/root.zig");
 pub const semantic = @import("semantic/root.zig");
 pub const codegen = @import("codegen/root.zig");
+pub const dialect_enabled = dialect.enabled;
+pub const dialect_schema = dialect.schema;
 
 test {
     _ = codegen;

--- a/src/parser/semantic/scope.zig
+++ b/src/parser/semantic/scope.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
+const dialect = @import("dialect");
 const ecmascript = @import("../ecmascript.zig");
 
 const Allocator = std.mem.Allocator;
@@ -302,6 +303,31 @@ pub const ScopeTracker = struct {
                 try self.pushScope(.class, index, flags);
             },
             .static_block => try self.pushScope(.static_block, index, self.inheritStrictFlag()),
+            .dialect_node => |node| {
+                if (comptime !dialect.enabled) {
+                    comptime std.debug.assert(@typeInfo(dialect.Store).@"struct".fields.len == 0);
+                    comptime std.debug.assert(@sizeOf(dialect.Store) == 0);
+                    return;
+                }
+                std.debug.assert(self.tree.dialect_store.records.items.len > 0);
+                std.debug.assert(node.record_index < self.tree.dialect_store.records.items.len);
+                const record = self.tree.dialect_store.records.items[node.record_index];
+                switch (record) {
+                    inline else => |payload| {
+                        const T = @TypeOf(payload);
+                        if (comptime @hasDecl(T, "scope_role")) {
+                            comptime std.debug.assert(
+                                @typeInfo(@TypeOf(T.scope_role)).@"enum".fields.len == 2,
+                            );
+                            comptime std.debug.assert(@sizeOf(@TypeOf(T.scope_role)) == 1);
+                            switch (T.scope_role) {
+                                .none => {},
+                                .block => try self.pushScope(.block, index, self.inheritStrictFlag()),
+                            }
+                        }
+                    },
+                }
+            },
             .decorator => {
                 // decorators evaluate in the scope enclosing the class:
                 // neither its type parameters nor an expression's own

--- a/src/parser/syntax/expressions.zig
+++ b/src/parser/syntax/expressions.zig
@@ -66,6 +66,10 @@ const DialectHost = struct {
         return statements.parseStatement(parser, .{});
     }
 
+    pub fn parseExpression(parser: *Parser) Error!?ast.NodeIndex {
+        return parseDialectExpression(parser);
+    }
+
     pub fn currentToken(parser: *const Parser) TokenTag {
         return parser.current_token.tag;
     }
@@ -153,6 +157,10 @@ const DialectHost = struct {
         };
     }
 };
+
+fn parseDialectExpression(parser: *Parser) Error!?ast.NodeIndex {
+    return parseExpression(parser, Precedence.Assignment, .{});
+}
 
 pub fn parseExpression(
     parser: *Parser,

--- a/src/parser/syntax/expressions.zig
+++ b/src/parser/syntax/expressions.zig
@@ -5,6 +5,7 @@
 const ast = @import("../ast.zig");
 const Parser = @import("../parser.zig").Parser;
 const Error = @import("../parser.zig").Error;
+const dialect = @import("dialect");
 const TokenTag = @import("../token.zig").TokenTag;
 const Token = @import("../token.zig").Token;
 const std = @import("std");
@@ -37,6 +38,120 @@ const ParseExpressionOpts = struct {
     /// recursive calls (parens, computed members, ...) leave it `false`
     /// so `in` resets to allowed.
     respect_allow_in: bool = false,
+};
+
+const DialectHost = struct {
+    pub const NodeIndex = ast.NodeIndex;
+    pub const NodeData = ast.NodeData;
+    pub const NodeTag = std.meta.Tag(ast.NodeData);
+    pub const IndexRange = ast.IndexRange;
+    pub const Span = ast.Span;
+    pub const Value = ast.String;
+    pub const Token = TokenTag;
+    pub const ErrorType = Error;
+
+    pub fn advance(parser: *Parser) Error!bool {
+        return (try parser.advance()) != null;
+    }
+
+    pub fn parseBlock(parser: *Parser) Error!?ast.NodeIndex {
+        return statements.parseBlockStatement(parser);
+    }
+
+    pub fn parseBlockWithTemporaryReturn(parser: *Parser, allow_return: bool) Error!?ast.NodeIndex {
+        return statements.parseBlockStatementWithTemporaryReturn(parser, allow_return);
+    }
+
+    pub fn parseStatement(parser: *Parser) Error!?ast.NodeIndex {
+        return statements.parseStatement(parser, .{});
+    }
+
+    pub fn currentToken(parser: *const Parser) TokenTag {
+        return parser.current_token.tag;
+    }
+
+    pub fn currentSpan(parser: *const Parser) ast.Span {
+        return parser.current_token.span;
+    }
+
+    pub fn data(parser: *const Parser, node: ast.NodeIndex) ast.NodeData {
+        return parser.tree.data(node);
+    }
+    pub fn extra(parser: *const Parser, range: ast.IndexRange) []const ast.NodeIndex {
+        return parser.tree.extra(range);
+    }
+    pub fn string(parser: *const Parser, value: ast.String) []const u8 {
+        return parser.tree.string(value);
+    }
+    pub fn source(parser: *const Parser) []const u8 {
+        return parser.source;
+    }
+    pub fn sourceText(parser: *const Parser, span: ast.Span) []const u8 {
+        return parser.spanText(span);
+    }
+    pub fn nodeSpan(parser: *const Parser, node: ast.NodeIndex) ast.Span {
+        return parser.tree.span(node);
+    }
+    pub fn allocator(parser: *Parser) std.mem.Allocator {
+        return parser.allocator();
+    }
+    pub fn addString(parser: *Parser, value: []const u8) Error!ast.String {
+        return parser.tree.addString(value);
+    }
+    pub fn addExtra(parser: *Parser, nodes: []const ast.NodeIndex) Error!ast.IndexRange {
+        return parser.tree.addExtra(nodes);
+    }
+    pub fn addNode(parser: *Parser, data_: ast.NodeData, span: ast.Span) Error!ast.NodeIndex {
+        return parser.tree.addNode(data_, span);
+    }
+    pub fn addDialectNode(parser: *Parser, record: dialect.Record, span: ast.Span) Error!ast.NodeIndex {
+        return parser.addDialectNode(record, span);
+    }
+    pub fn overlayRecord(parser: *const Parser, host: ast.NodeIndex) ?dialect.Record {
+        const index = parser.tree.dialectOverlay(@intFromEnum(host)) orelse return null;
+        return parser.tree.dialect_store.records.items[index];
+    }
+    pub fn reportWithHelp(parser: *Parser, span: ast.Span, message: []const u8, help: []const u8) Error!void {
+        return parser.report(span, message, .{ .help = help });
+    }
+    pub fn report(parser: *Parser, span: ast.Span, message: []const u8) Error!void {
+        return parser.report(span, message, .{});
+    }
+    pub fn currentReturnContext(parser: *const Parser) bool {
+        return parser.context.@"return";
+    }
+
+    pub fn parseArrayCover(parser: *Parser) Error!?ast.NodeIndex {
+        return parseArrayExpression(parser, true);
+    }
+
+    pub fn parseObjectCover(parser: *Parser) Error!?ast.NodeIndex {
+        return parseObjectExpression(parser, true);
+    }
+
+    pub fn expressionToAssignablePattern(parser: *Parser, node: ast.NodeIndex) Error!void {
+        return grammar.expressionToPattern(parser, node, .assignable);
+    }
+
+    pub fn extendNodeStart(parser: *Parser, node: ast.NodeIndex, start: u32) void {
+        const span = parser.tree.span(node);
+        std.debug.assert(start <= span.start);
+        parser.tree.setSpan(node, .{ .start = start, .end = span.end });
+    }
+
+    pub fn addRecord(parser: *Parser, record: anytype) Error!u32 {
+        return parser.tree.addDialectRecord(record) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
+
+    pub fn addOverlay(parser: *Parser, host: ast.NodeIndex, record_index: u32) Error!void {
+        parser.tree.addDialectOverlay(@intFromEnum(host), record_index) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
 };
 
 pub fn parseExpression(
@@ -117,6 +232,13 @@ fn parsePrefix(parser: *Parser, opts: ParseExpressionOpts, precedence: u8) Error
 
     if (tag == .increment or tag == .decrement) {
         return parseUpdateExpression(parser, true, .null);
+    }
+
+    if (comptime dialect.enabled and @hasDecl(dialect, "lazy_assignment_pattern")) {
+        switch (try dialect.lazy_assignment_pattern(DialectHost, parser)) {
+            .handled => |node| return node,
+            .unhandled => {},
+        }
     }
 
     if (tag.isUnaryOperator()) {
@@ -248,6 +370,18 @@ pub inline fn parsePrimaryExpression(
         .function => functions.parseFunction(parser, .{ .is_expression = true }, null),
         .class => class.parseClass(parser, .{ .is_expression = true }, null),
         .at => blk: {
+            if (comptime dialect.enabled and @hasDecl(dialect, "expression_at_code_block")) {
+                switch (try dialect.expression_at_code_block(DialectHost, parser)) {
+                    .handled => |node| break :blk node,
+                    .unhandled => {},
+                }
+            }
+            if (comptime dialect.enabled and @hasDecl(dialect, "expression_at_control_flow")) {
+                switch (try dialect.expression_at_control_flow(DialectHost, parser)) {
+                    .handled => |node| break :blk node,
+                    .unhandled => {},
+                }
+            }
             const decorators_start = parser.current_token.span.start;
             const decorators = try extensions.parseDecorators(parser) orelse break :blk null;
             break :blk try class.parseClassDecorated(

--- a/src/parser/syntax/for_loop.zig
+++ b/src/parser/syntax/for_loop.zig
@@ -1,8 +1,60 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
 const Precedence = @import("../token.zig").Precedence;
+const TokenTag = @import("../token.zig").TokenTag;
 const Parser = @import("../parser.zig").Parser;
 const Error = @import("../parser.zig").Error;
+const dialect = @import("dialect");
+
+const DialectHost = struct {
+    pub const ErrorType = Error;
+    pub const NodeIndex = ast.NodeIndex;
+    pub const Token = TokenTag;
+    pub const Context = struct { start: u32, left: ast.NodeIndex, right: ast.NodeIndex, is_for_await: bool };
+
+    pub fn currentToken(parser: *const Parser) TokenTag {
+        return parser.current_token.tag;
+    }
+
+    pub fn advance(parser: *Parser) Error!bool {
+        return (try parser.advance()) != null;
+    }
+
+    pub fn parseExpression(parser: *Parser) Error!?ast.NodeIndex {
+        return expressions.parseExpression(parser, Precedence.Assignment, .{});
+    }
+
+    pub fn expect(parser: *Parser, comptime tag: TokenTag, message: []const u8) Error!bool {
+        return parser.expect(tag, message, null);
+    }
+
+    pub fn parseStatement(parser: *Parser) Error!?ast.NodeIndex {
+        return statements.parseStatement(parser, .{ .can_be_single_statement_context = true });
+    }
+
+    pub fn addForOf(parser: *Parser, context: Context, body: ast.NodeIndex) Error!ast.NodeIndex {
+        return parser.tree.addNode(.{ .for_of_statement = .{
+            .left = context.left,
+            .right = context.right,
+            .body = body,
+            .await = context.is_for_await,
+        } }, .{ .start = context.start, .end = parser.tree.span(body).end });
+    }
+
+    pub fn addRecord(parser: *Parser, record: anytype) Error!u32 {
+        return parser.tree.addDialectRecord(record) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
+
+    pub fn addOverlay(parser: *Parser, host: ast.NodeIndex, record_index: u32) Error!void {
+        parser.tree.addDialectOverlay(@intFromEnum(host), record_index) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
+};
 
 const expressions = @import("expressions.zig");
 const variables = @import("variables.zig");
@@ -346,6 +398,18 @@ fn parseForOfStatementRest(
 
     const right = try expressions.parseExpression(parser, Precedence.Assignment, .{}) orelse
         return null;
+
+    if (comptime dialect.enabled and @hasDecl(dialect, "for_of_tail")) {
+        switch (try dialect.for_of_tail(DialectHost, parser, .{
+            .start = start,
+            .left = left,
+            .right = right,
+            .is_for_await = is_for_await,
+        })) {
+            .handled => |node| return node,
+            .unhandled => {},
+        }
+    }
 
     if (!try parser.expect(.right_paren, "Expected ')' after for-of expression", null)) {
         return null;

--- a/src/parser/syntax/for_loop.zig
+++ b/src/parser/syntax/for_loop.zig
@@ -16,6 +16,14 @@ const DialectHost = struct {
         return parser.current_token.tag;
     }
 
+    pub fn currentSpan(parser: *const Parser) ast.Span {
+        return parser.current_token.span;
+    }
+
+    pub fn sourceText(parser: *const Parser, span: ast.Span) []const u8 {
+        return parser.spanText(span);
+    }
+
     pub fn advance(parser: *Parser) Error!bool {
         return (try parser.advance()) != null;
     }

--- a/src/parser/syntax/functions.zig
+++ b/src/parser/syntax/functions.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const Parser = @import("../parser.zig").Parser;
 const Error = @import("../parser.zig").Error;
+const dialect = @import("dialect");
 const TokenTag = @import("../token.zig").TokenTag;
 
 const literals = @import("literals.zig");
@@ -18,6 +19,90 @@ const ParseFunctionOpts = struct {
     /// `export default function`: name is optional but the result is
     /// still a `FunctionDeclaration`.
     is_default_export: bool = false,
+};
+
+const DialectHost = struct {
+    pub const NodeIndex = ast.NodeIndex;
+    pub const NodeData = ast.NodeData;
+    pub const NodeTag = std.meta.Tag(ast.NodeData);
+    pub const IndexRange = ast.IndexRange;
+    pub const Span = ast.Span;
+    pub const Value = ast.String;
+    pub const Token = TokenTag;
+    pub const ErrorType = Error;
+
+    pub fn currentToken(parser: *const Parser) TokenTag {
+        return parser.current_token.tag;
+    }
+    pub fn currentSpan(parser: *const Parser) ast.Span {
+        return parser.current_token.span;
+    }
+    pub fn data(parser: *const Parser, node: ast.NodeIndex) ast.NodeData {
+        return parser.tree.data(node);
+    }
+    pub fn extra(parser: *const Parser, range: ast.IndexRange) []const ast.NodeIndex {
+        return parser.tree.extra(range);
+    }
+    pub fn string(parser: *const Parser, value: ast.String) []const u8 {
+        return parser.tree.string(value);
+    }
+    pub fn source(parser: *const Parser) []const u8 {
+        return parser.source;
+    }
+    pub fn sourceText(parser: *const Parser, span: ast.Span) []const u8 {
+        return parser.spanText(span);
+    }
+    pub fn nodeSpan(parser: *const Parser, node: ast.NodeIndex) ast.Span {
+        return parser.tree.span(node);
+    }
+    pub fn allocator(parser: *Parser) std.mem.Allocator {
+        return parser.allocator();
+    }
+    pub fn addString(parser: *Parser, value: []const u8) Error!ast.String {
+        return parser.tree.addString(value);
+    }
+    pub fn addExtra(parser: *Parser, nodes: []const ast.NodeIndex) Error!ast.IndexRange {
+        return parser.tree.addExtra(nodes);
+    }
+    pub fn addNode(parser: *Parser, data_: ast.NodeData, span: ast.Span) Error!ast.NodeIndex {
+        return parser.tree.addNode(data_, span);
+    }
+    pub fn addDialectNode(parser: *Parser, record: dialect.Record, span: ast.Span) Error!ast.NodeIndex {
+        return parser.addDialectNode(record, span);
+    }
+    pub fn reportWithHelp(parser: *Parser, span: ast.Span, message: []const u8, help: []const u8) Error!void {
+        return parser.report(span, message, .{ .help = help });
+    }
+    pub fn currentReturnContext(parser: *const Parser) bool {
+        return parser.context.@"return";
+    }
+
+    pub fn parseBody(parser: *Parser) Error!?ast.NodeIndex {
+        return parseFunctionBodyContinuation(parser);
+    }
+    pub fn advance(parser: *Parser) Error!bool {
+        return (try parser.advance()) != null;
+    }
+    pub fn parseBlockWithTemporaryReturn(parser: *Parser, allow_return: bool) Error!?ast.NodeIndex {
+        const saved = parser.context.@"return";
+        parser.context.@"return" = allow_return;
+        defer parser.context.@"return" = saved;
+        return parseFunctionBodyContinuation(parser);
+    }
+
+    pub fn addRecord(parser: *Parser, record: anytype) Error!u32 {
+        return parser.tree.addDialectRecord(record) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
+
+    pub fn addOverlay(parser: *Parser, host: ast.NodeIndex, record_index: u32) Error!void {
+        parser.tree.addDialectOverlay(@intFromEnum(host), record_index) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
 };
 
 pub fn parseFunction(
@@ -129,8 +214,14 @@ pub fn parseFunction(
     }
 
     // ts ambient declarations and overload signatures are body-less.
-    const has_body = !is_ambient_declaration and
+    var has_body = !is_ambient_declaration and
         (!is_ts or is_function_expression or parser.current_token.tag == .left_brace);
+    if (comptime dialect.enabled and @hasDecl(dialect, "function_body_starts")) {
+        switch (dialect.function_body_starts(DialectHost, parser)) {
+            .handled => |value| has_body = value,
+            .unhandled => {},
+        }
+    }
     const body: ast.NodeIndex = if (has_body)
         try parseFunctionBody(parser) orelse .null
     else
@@ -186,7 +277,19 @@ pub fn parseFunction(
     });
 }
 
-pub fn parseFunctionBody(parser: *Parser) Error!?ast.NodeIndex {
+pub const parseFunctionBody = if (dialect.enabled and @hasDecl(dialect, "function_body"))
+    parseFunctionBodyDialect
+else
+    parseFunctionBodyContinuation;
+
+fn parseFunctionBodyDialect(parser: *Parser) Error!?ast.NodeIndex {
+    switch (try dialect.function_body(DialectHost, parser)) {
+        .handled => |node| return node,
+        .unhandled => return parseFunctionBodyContinuation(parser),
+    }
+}
+
+fn parseFunctionBodyContinuation(parser: *Parser) Error!?ast.NodeIndex {
     const start = parser.current_token.span.start;
 
     if (!try parser.expect(

--- a/src/parser/syntax/jsx/root.zig
+++ b/src/parser/syntax/jsx/root.zig
@@ -218,7 +218,6 @@ inline fn finishJsxElement(parser: *Parser, opening: ast.NodeIndex, comptime con
     // element with children: <elem>...</elem>
     const children = try parseJsxChildren(parser, opening_end) orelse return null;
 
-    std.debug.assert(parser.current_token.tag == .less_than);
     const closing_checkpoint = parser.checkpoint();
     const closing_start = parser.current_token.span.start;
     const diagnostics_len = parser.diagnostics.items.len;

--- a/src/parser/syntax/jsx/root.zig
+++ b/src/parser/syntax/jsx/root.zig
@@ -1,8 +1,11 @@
 const std = @import("std");
 const ast = @import("../../ast.zig");
 const Precedence = @import("../../token.zig").Precedence;
+const TokenTag = @import("../../token.zig").TokenTag;
+const RawToken = @import("../../token.zig").Token;
 const Parser = @import("../../parser.zig").Parser;
 const Error = @import("../../parser.zig").Error;
+const dialect = @import("dialect");
 
 const literals = @import("../literals.zig");
 const expressions = @import("../expressions.zig");
@@ -16,6 +19,139 @@ const JsxElementContext = enum {
     child,
     /// attribute value, restores jsx_tag mode
     attribute,
+};
+
+const DialectHost = struct {
+    pub const NodeIndex = ast.NodeIndex;
+    pub const NodeData = ast.NodeData;
+    pub const NodeTag = std.meta.Tag(ast.NodeData);
+    pub const IndexRange = ast.IndexRange;
+    pub const Value = ast.String;
+    pub const Span = ast.Span;
+    pub const Token = TokenTag;
+    pub const ErrorType = Error;
+
+    pub fn currentToken(parser: *const Parser) TokenTag {
+        return parser.current_token.tag;
+    }
+
+    pub fn currentSpan(parser: *const Parser) ast.Span {
+        return parser.current_token.span;
+    }
+    pub fn data(parser: *const Parser, node: ast.NodeIndex) ast.NodeData {
+        return parser.tree.data(node);
+    }
+    pub fn extra(parser: *const Parser, range: ast.IndexRange) []const ast.NodeIndex {
+        return parser.tree.extra(range);
+    }
+    pub fn string(parser: *const Parser, value: ast.String) []const u8 {
+        return parser.tree.string(value);
+    }
+    pub fn source(parser: *const Parser) []const u8 {
+        return parser.source;
+    }
+    pub fn sourceText(parser: *const Parser, span: ast.Span) []const u8 {
+        return parser.spanText(span);
+    }
+    pub fn allocator(parser: *Parser) std.mem.Allocator {
+        return parser.allocator();
+    }
+    pub fn addString(parser: *Parser, value: []const u8) Error!ast.String {
+        return parser.tree.addString(value);
+    }
+    pub fn addExtra(parser: *Parser, nodes: []const ast.NodeIndex) Error!ast.IndexRange {
+        return parser.tree.addExtra(nodes);
+    }
+    pub fn addNode(parser: *Parser, data_: ast.NodeData, span: ast.Span) Error!ast.NodeIndex {
+        return parser.tree.addNode(data_, span);
+    }
+    pub fn addDialectNode(parser: *Parser, record: dialect.Record, span: ast.Span) Error!ast.NodeIndex {
+        return parser.addDialectNode(record, span);
+    }
+    pub fn reportWithHelp(parser: *Parser, span: ast.Span, message: []const u8, help: []const u8) Error!void {
+        return parser.report(span, message, .{ .help = help });
+    }
+    pub fn currentReturnContext(parser: *const Parser) bool {
+        return parser.context.@"return";
+    }
+    pub fn resumeAfterRawSpan(
+        parser: *Parser,
+        end: u32,
+        comptime context: JsxElementContext,
+    ) Error!bool {
+        if (end > parser.source.len) return false;
+        parser.lexer.rewindTo(end);
+        parser.current_token = RawToken.eof(end);
+        parser.prev_token_end = end;
+        switch (context) {
+            .child => parser.setLexerMode(.normal),
+            .top_level => {
+                parser.setLexerMode(.normal);
+                return (try parser.advance()) != null;
+            },
+            .attribute => {
+                parser.setLexerMode(.jsx_tag);
+                return (try parser.advance()) != null;
+            },
+        }
+        return true;
+    }
+
+    pub fn nodeSpan(parser: *const Parser, node: ast.NodeIndex) ast.Span {
+        return parser.tree.span(node);
+    }
+
+    pub fn sourceSlice(parser: *const Parser, start: u32, end: u32) ast.String {
+        return parser.tree.sourceSlice(start, end);
+    }
+
+    pub fn addTextNode(parser: *Parser, value: ast.String, span: ast.Span) Error!ast.NodeIndex {
+        return parser.tree.addNode(.{ .jsx_text = .{ .value = value } }, span);
+    }
+
+    pub fn parseChild(parser: *Parser) Error!?ast.NodeIndex {
+        return parseJsxChildFromLeftBrace(parser);
+    }
+
+    pub fn parseBlockWithTemporaryReturn(parser: *Parser, allow_return: bool) Error!?ast.NodeIndex {
+        return parser.parseDialectBlockWithTemporaryReturn(allow_return);
+    }
+
+    pub fn finishElement(parser: *Parser, opening: ast.NodeIndex, comptime context: JsxElementContext) Error!?ast.NodeIndex {
+        return finishJsxElement(parser, opening, context);
+    }
+
+    pub fn parseTagExpressionContainer(parser: *Parser) Error!?ast.NodeIndex {
+        return parseJsxExpressionContainer(parser);
+    }
+
+    pub fn namesEqual(parser: *const Parser, left: ast.NodeIndex, right: ast.NodeIndex) bool {
+        const left_span = parser.tree.span(left);
+        const right_span = parser.tree.span(right);
+        return std.mem.eql(u8, parser.spanText(left_span), parser.spanText(right_span));
+    }
+
+    pub fn advance(parser: *Parser) Error!bool {
+        return (try parser.advance()) != null;
+    }
+
+    pub fn report(parser: *Parser, span: ast.Span, message: []const u8) Error!void {
+        return parser.report(span, message, .{});
+    }
+
+    pub fn addRecord(parser: *Parser, record: anytype) Error!u32 {
+        return parser.tree.addDialectRecord(record) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
+
+    pub fn addOverlay(parser: *Parser, host: ast.NodeIndex, record_index: u32) Error!void {
+        parser.tree.addDialectOverlay(@intFromEnum(host), record_index) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
 };
 
 inline fn enterJsxTag(parser: *Parser) void {
@@ -33,8 +169,6 @@ pub fn parseJsxExpression(parser: *Parser) Error!?ast.NodeIndex {
 }
 
 fn parseJsxElement(parser: *Parser, comptime context: JsxElementContext) Error!?ast.NodeIndex {
-    const start = parser.current_token.span.start;
-
     // peek in jsx_tag mode so a fragment's '>' is not glued to the character after it,
     // as in `<>=</>`
     enterJsxTag(parser);
@@ -48,7 +182,27 @@ fn parseJsxElement(parser: *Parser, comptime context: JsxElementContext) Error!?
 
     const opening = try parseJsxOpeningElement(parser, context) orelse return null;
     const opening_data = parser.tree.data(opening).jsx_opening_element;
+
+    if (comptime dialect.enabled and @hasDecl(dialect, "jsx_element_after_open")) {
+        switch (try dialect.jsx_element_after_open(DialectHost, parser, opening, context)) {
+            .handled => |node| return node,
+            .unhandled => {},
+        }
+    }
+    if (comptime dialect.enabled and @hasDecl(dialect, "validate_jsx_element_name")) {
+        switch (try dialect.validate_jsx_element_name(DialectHost, parser, opening_data.name)) {
+            .handled => {},
+            .unhandled => {},
+        }
+    }
+
+    return finishJsxElement(parser, opening, context);
+}
+
+inline fn finishJsxElement(parser: *Parser, opening: ast.NodeIndex, comptime context: JsxElementContext) Error!?ast.NodeIndex {
+    const opening_data = parser.tree.data(opening).jsx_opening_element;
     const opening_end = parser.tree.span(opening).end;
+    const start = parser.tree.span(opening).start;
 
     // self-closing element: <elem />
     if (opening_data.self_closing) {
@@ -284,6 +438,12 @@ fn parseJsxClosingElement(
 }
 
 fn jsxNamesMatch(parser: *const Parser, a: ast.NodeIndex, b: ast.NodeIndex) bool {
+    if (comptime dialect.enabled and @hasDecl(dialect, "jsx_names_match")) {
+        switch (dialect.jsx_names_match(DialectHost, parser, a, b)) {
+            .handled => |value| return value,
+            .unhandled => {},
+        }
+    }
     const span_a = parser.tree.span(a);
     const span_b = parser.tree.span(b);
 
@@ -313,9 +473,16 @@ fn parseJsxChildren(parser: *Parser, gt_end: u32) Error!?ast.IndexRange {
         const text_token = parser.lexer.reScanJsxText(scan_from);
 
         if (text_token.len() > 0) {
+            var text_value = parser.tree.sourceSlice(text_token.span.start, text_token.span.end);
+            if (comptime dialect.enabled and @hasDecl(dialect, "jsx_text_value")) {
+                switch (try dialect.jsx_text_value(DialectHost, parser, text_token.span)) {
+                    .handled => |value| text_value = value,
+                    .unhandled => {},
+                }
+            }
             const text_node = try parser.tree.addNode(.{
                 .jsx_text = .{
-                    .value = parser.tree.sourceSlice(text_token.span.start, text_token.span.end),
+                    .value = text_value,
                 },
             }, text_token.span);
 
@@ -340,6 +507,31 @@ fn parseJsxChildren(parser: *Parser, gt_end: u32) Error!?ast.IndexRange {
                 const child = try parseJsxChildFromLeftBrace(parser) orelse return null;
                 scan_from = parser.tree.span(child).end;
                 try parser.scratch_b.append(parser.allocator(), child);
+            },
+            .at => {
+                if (comptime dialect.enabled and @hasDecl(dialect, "jsx_child_at_code_block")) {
+                    switch (try dialect.jsx_child_at_code_block(DialectHost, parser)) {
+                        .handled => |node| {
+                            const child = node orelse return null;
+                            scan_from = parser.tree.span(child).end;
+                            try parser.scratch_b.append(parser.allocator(), child);
+                            continue;
+                        },
+                        .unhandled => {},
+                    }
+                }
+                if (comptime dialect.enabled and @hasDecl(dialect, "jsx_child_at_control_flow")) {
+                    switch (try dialect.jsx_child_at_control_flow(DialectHost, parser)) {
+                        .handled => |node| {
+                            const child = node orelse return null;
+                            scan_from = parser.tree.span(child).end;
+                            try parser.scratch_b.append(parser.allocator(), child);
+                            continue;
+                        },
+                        .unhandled => {},
+                    }
+                }
+                break;
             },
             .greater_than, .right_brace => {
                 try parser.report(
@@ -618,6 +810,16 @@ fn parseJsxSpreadAttribute(parser: *Parser) Error!?ast.NodeIndex {
 
 // https://facebook.github.io/jsx/#prod-JSXElementName
 fn parseJsxElementName(parser: *Parser) Error!?ast.NodeIndex {
+    if (comptime dialect.enabled and @hasDecl(dialect, "jsx_element_name")) {
+        switch (try dialect.jsx_element_name(DialectHost, parser)) {
+            .handled => |node| return node,
+            .unhandled => {},
+        }
+    }
+    return parseJsxElementNameContinuation(parser);
+}
+
+inline fn parseJsxElementNameContinuation(parser: *Parser) Error!?ast.NodeIndex {
     if (parser.current_token.tag != .jsx_identifier) {
         try parser.reportExpected(
             parser.current_token.span,

--- a/src/parser/syntax/jsx/root.zig
+++ b/src/parser/syntax/jsx/root.zig
@@ -113,6 +113,10 @@ const DialectHost = struct {
         return parseJsxChildFromLeftBrace(parser);
     }
 
+    pub fn parseExpression(parser: *Parser) Error!?ast.NodeIndex {
+        return expressions.parseExpression(parser, Precedence.Assignment, .{});
+    }
+
     pub fn parseBlockWithTemporaryReturn(parser: *Parser, allow_return: bool) Error!?ast.NodeIndex {
         return parser.parseDialectBlockWithTemporaryReturn(allow_return);
     }

--- a/src/parser/syntax/jsx/root.zig
+++ b/src/parser/syntax/jsx/root.zig
@@ -218,19 +218,44 @@ inline fn finishJsxElement(parser: *Parser, opening: ast.NodeIndex, comptime con
     // element with children: <elem>...</elem>
     const children = try parseJsxChildren(parser, opening_end) orelse return null;
 
+    std.debug.assert(parser.current_token.tag == .less_than);
+    const closing_checkpoint = parser.checkpoint();
+    const closing_start = parser.current_token.span.start;
+    const diagnostics_len = parser.diagnostics.items.len;
     const closing = try parseJsxClosingElement(
         parser,
         opening_data.name,
         context,
-    ) orelse return null;
+    );
+    if (closing == null) {
+        if (context != .child or !parser.loose) return null;
+        if (parser.diagnostics.items.len != diagnostics_len + 1) return null;
+
+        const diagnostic = parser.diagnostics.items[diagnostics_len];
+        if (!std.mem.startsWith(u8, diagnostic.message, "Expected closing tag for '")) {
+            return null;
+        }
+
+        parser.rewind(closing_checkpoint);
+        std.debug.assert(parser.current_token.tag == .less_than);
+        std.debug.assert(parser.current_token.span.start == closing_start);
+        return try parser.tree.addNode(.{
+            .jsx_element = .{
+                .opening_element = opening,
+                .children = children,
+                .closing_element = .null,
+            },
+        }, .{ .start = start, .end = closing_start });
+    }
+    const closing_index = closing.?;
 
     return try parser.tree.addNode(.{
         .jsx_element = .{
             .opening_element = opening,
             .children = children,
-            .closing_element = closing,
+            .closing_element = closing_index,
         },
-    }, .{ .start = start, .end = parser.tree.span(closing).end });
+    }, .{ .start = start, .end = parser.tree.span(closing_index).end });
 }
 
 // https://facebook.github.io/jsx/#prod-JSXFragment

--- a/src/parser/syntax/modules.zig
+++ b/src/parser/syntax/modules.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const ast = @import("../ast.zig");
 const Parser = @import("../parser.zig").Parser;
 const Error = @import("../parser.zig").Error;
+const dialect = @import("dialect");
 const Token = @import("../token.zig").Token;
 const TokenTag = @import("../token.zig").TokenTag;
 const Precedence = @import("../token.zig").Precedence;
@@ -15,6 +16,14 @@ const class = @import("class.zig");
 const extensions = @import("extensions.zig");
 const variables = @import("variables.zig");
 const ts = @import("ts/statements.zig");
+
+const DialectHost = struct {
+    pub const NodeIndex = ast.NodeIndex;
+    pub const ErrorType = Error;
+    pub fn parseIdentifier(parser: *Parser) Error!?ast.NodeIndex {
+        return literals.parseIdentifier(parser);
+    }
+};
 
 pub fn parseImportDeclaration(parser: *Parser) Error!?ast.NodeIndex {
     std.debug.assert(parser.current_token.tag == .import);
@@ -945,6 +954,12 @@ fn parseModuleExportName(parser: *Parser) Error!?ast.NodeIndex {
 // module string
 fn parseModuleSpecifier(parser: *Parser) Error!?ast.NodeIndex {
     if (parser.current_token.tag != .string_literal) {
+        if (comptime dialect.enabled and @hasDecl(dialect, "module_specifier")) {
+            switch (try dialect.module_specifier(DialectHost, parser)) {
+                .handled => |node| return node,
+                .unhandled => {},
+            }
+        }
         try parser.reportExpected(parser.current_token.span, "Expected module specifier", .{
             .help = "Module specifiers must be string literals, e.g., './module.js' or 'package'",
         });

--- a/src/parser/syntax/patterns.zig
+++ b/src/parser/syntax/patterns.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const Parser = @import("../parser.zig").Parser;
 const Error = @import("../parser.zig").Error;
+const dialect = @import("dialect");
 const ast = @import("../ast.zig");
+const TokenTag = @import("../token.zig").TokenTag;
 const Precedence = @import("../token.zig").Precedence;
 
 const array = @import("array.zig");
@@ -10,7 +12,57 @@ const literals = @import("literals.zig");
 const expressions = @import("expressions.zig");
 const ts = @import("ts/types.zig");
 
+const DialectHost = struct {
+    pub const NodeIndex = ast.NodeIndex;
+    pub const Token = TokenTag;
+    pub const ErrorType = Error;
+
+    pub fn currentToken(parser: *const Parser) TokenTag {
+        return parser.current_token.tag;
+    }
+
+    pub fn currentSpan(parser: *const Parser) ast.Span {
+        return parser.current_token.span;
+    }
+
+    pub fn advance(parser: *Parser) Error!bool {
+        return (try parser.advance()) != null;
+    }
+
+    pub fn extendNodeStart(parser: *Parser, node: ast.NodeIndex, start: u32) void {
+        parser.tree.setSpan(node, .{ .start = start, .end = parser.tree.span(node).end });
+    }
+
+    pub fn parseOrdinaryBinding(parser: *Parser) Error!?ast.NodeIndex {
+        return parseBindingPatternContinuation(parser);
+    }
+
+    pub fn addRecord(parser: *Parser, record: anytype) Error!u32 {
+        return parser.tree.addDialectRecord(record) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
+
+    pub fn addOverlay(parser: *Parser, host: ast.NodeIndex, record_index: u32) Error!void {
+        parser.tree.addDialectOverlay(@intFromEnum(host), record_index) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
+};
+
 pub inline fn parseBindingPattern(parser: *Parser) Error!?ast.NodeIndex {
+    if (comptime dialect.enabled and @hasDecl(dialect, "binding_pattern")) {
+        switch (try dialect.binding_pattern(DialectHost, parser)) {
+            .handled => |node| return node,
+            .unhandled => {},
+        }
+    }
+    return parseBindingPatternContinuation(parser);
+}
+
+inline fn parseBindingPatternContinuation(parser: *Parser) Error!?ast.NodeIndex {
     if (parser.current_token.tag.isIdentifierLike()) {
         return literals.parseBindingIdentifier(parser);
     }

--- a/src/parser/syntax/statements.zig
+++ b/src/parser/syntax/statements.zig
@@ -4,6 +4,7 @@ const TokenTag = @import("../token.zig").TokenTag;
 const Precedence = @import("../token.zig").Precedence;
 const Parser = @import("../parser.zig").Parser;
 const Error = @import("../parser.zig").Error;
+const dialect = @import("dialect");
 const expressions = @import("expressions.zig");
 const variables = @import("variables.zig");
 const literals = @import("literals.zig");
@@ -21,6 +22,87 @@ const ParseStatementOpts = struct {
     /// true when parsing the body of `if`, `while`, `do`, `for`, `with`, or labeled statements,
     /// where lexical declarations (`let`, `const`) are not allowed without a block.
     can_be_single_statement_context: bool = false,
+};
+
+const DialectHost = struct {
+    pub const NodeIndex = ast.NodeIndex;
+    pub const NodeData = ast.NodeData;
+    pub const NodeTag = std.meta.Tag(ast.NodeData);
+    pub const IndexRange = ast.IndexRange;
+    pub const Span = ast.Span;
+    pub const Value = ast.String;
+    pub const Token = TokenTag;
+    pub const ErrorType = Error;
+    pub fn currentToken(parser: *const Parser) TokenTag {
+        return parser.current_token.tag;
+    }
+    pub fn currentSpan(parser: *const Parser) ast.Span {
+        return parser.current_token.span;
+    }
+    pub fn expect(parser: *Parser, comptime tag: TokenTag, message: []const u8) Error!bool {
+        return parser.expect(tag, message, null);
+    }
+    pub fn data(parser: *const Parser, node: ast.NodeIndex) ast.NodeData {
+        return parser.tree.data(node);
+    }
+    pub fn extra(parser: *const Parser, range: ast.IndexRange) []const ast.NodeIndex {
+        return parser.tree.extra(range);
+    }
+    pub fn string(parser: *const Parser, value: ast.String) []const u8 {
+        return parser.tree.string(value);
+    }
+    pub fn source(parser: *const Parser) []const u8 {
+        return parser.source;
+    }
+    pub fn sourceText(parser: *const Parser, span: ast.Span) []const u8 {
+        return parser.spanText(span);
+    }
+    pub fn nodeSpan(parser: *const Parser, node: ast.NodeIndex) ast.Span {
+        return parser.tree.span(node);
+    }
+    pub fn allocator(parser: *Parser) std.mem.Allocator {
+        return parser.allocator();
+    }
+    pub fn addString(parser: *Parser, value: []const u8) Error!ast.String {
+        return parser.tree.addString(value);
+    }
+    pub fn addExtra(parser: *Parser, nodes: []const ast.NodeIndex) Error!ast.IndexRange {
+        return parser.tree.addExtra(nodes);
+    }
+    pub fn addNode(parser: *Parser, data_: ast.NodeData, span: ast.Span) Error!ast.NodeIndex {
+        return parser.tree.addNode(data_, span);
+    }
+    pub fn addDialectNode(parser: *Parser, record: dialect.Record, span: ast.Span) Error!ast.NodeIndex {
+        return parser.addDialectNode(record, span);
+    }
+    pub fn overlayRecord(parser: *const Parser, host: ast.NodeIndex) ?dialect.Record {
+        const index = parser.tree.dialectOverlay(@intFromEnum(host)) orelse return null;
+        return parser.tree.dialect_store.records.items[index];
+    }
+    pub fn reportWithHelp(parser: *Parser, span: ast.Span, message: []const u8, help: []const u8) Error!void {
+        return parser.report(span, message, .{ .help = help });
+    }
+    pub fn report(parser: *Parser, span: ast.Span, message: []const u8) Error!void {
+        return parser.report(span, message, .{});
+    }
+    pub fn currentReturnContext(parser: *const Parser) bool {
+        return parser.context.@"return";
+    }
+    pub fn parseStatementExpression(parser: *Parser) Error!?ast.NodeIndex {
+        return parseExpressionStatement(parser);
+    }
+    pub fn advance(parser: *Parser) Error!bool {
+        return (try parser.advance()) != null;
+    }
+    pub fn parseExpression(parser: *Parser) Error!?ast.NodeIndex {
+        return expressions.parseExpression(parser, Precedence.Assignment, .{});
+    }
+    pub fn parseStatementNode(parser: *Parser) Error!?ast.NodeIndex {
+        return parseStatement(parser, .{});
+    }
+    pub fn parseBlockWithTemporaryReturn(parser: *Parser, allow_return: bool) Error!?ast.NodeIndex {
+        return parseBlockStatementWithTemporaryReturn(parser, allow_return);
+    }
 };
 
 pub fn parseStatement(parser: *Parser, opts: ParseStatementOpts) Error!?ast.NodeIndex {
@@ -76,6 +158,18 @@ pub fn parseStatement(parser: *Parser, opts: ParseStatementOpts) Error!?ast.Node
 /// `@dec class C` or `@dec export [default] class C`.
 fn parseDecoratedStatement(parser: *Parser) Error!?ast.NodeIndex {
     std.debug.assert(parser.current_token.tag == .at);
+    if (comptime dialect.enabled and @hasDecl(dialect, "statement_at_code_block")) {
+        switch (try dialect.statement_at_code_block(DialectHost, parser)) {
+            .handled => |node| return node,
+            .unhandled => {},
+        }
+    }
+    if (comptime dialect.enabled and @hasDecl(dialect, "statement_at_control_flow")) {
+        switch (try dialect.statement_at_control_flow(DialectHost, parser)) {
+            .handled => |node| return node,
+            .unhandled => {},
+        }
+    }
     const start = parser.current_token.span.start;
     const decorators = try extensions.parseDecorators(parser) orelse return null;
 
@@ -281,6 +375,16 @@ pub fn parseBlockStatement(parser: *Parser) Error!?ast.NodeIndex {
         .{ .block_statement = .{ .body = body } },
         .{ .start = start, .end = end },
     );
+}
+
+pub fn parseBlockStatementWithTemporaryReturn(
+    parser: *Parser,
+    allow_return: bool,
+) Error!?ast.NodeIndex {
+    const saved = parser.context.@"return";
+    parser.context.@"return" = allow_return;
+    defer parser.context.@"return" = saved;
+    return parseBlockStatement(parser);
 }
 
 /// https://tc39.es/ecma262/#sec-switch-statement

--- a/src/parser/syntax/statements.zig
+++ b/src/parser/syntax/statements.zig
@@ -103,6 +103,18 @@ const DialectHost = struct {
     pub fn parseBlockWithTemporaryReturn(parser: *Parser, allow_return: bool) Error!?ast.NodeIndex {
         return parseBlockStatementWithTemporaryReturn(parser, allow_return);
     }
+    pub fn addRecord(parser: *Parser, record: anytype) Error!u32 {
+        return parser.tree.addDialectRecord(record) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
+    pub fn addOverlay(parser: *Parser, host: ast.NodeIndex, record_index: u32) Error!void {
+        parser.tree.addDialectOverlay(@intFromEnum(host), record_index) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => unreachable,
+        };
+    }
 };
 
 pub fn parseStatement(parser: *Parser, opts: ParseStatementOpts) Error!?ast.NodeIndex {

--- a/src/parser/syntax/variables.zig
+++ b/src/parser/syntax/variables.zig
@@ -1,12 +1,20 @@
 const ast = @import("../ast.zig");
 const Parser = @import("../parser.zig").Parser;
 const Error = @import("../parser.zig").Error;
+const dialect = @import("dialect");
 const Precedence = @import("../token.zig").Precedence;
 const TokenTag = @import("../token.zig").TokenTag;
 const expressions = @import("expressions.zig");
 const patterns = @import("patterns.zig");
 const ts = @import("ts/types.zig");
 const std = @import("std");
+
+const DialectHost = struct {
+    pub const Token = TokenTag;
+    pub fn isIdentifierLike(token: TokenTag) bool {
+        return token.isIdentifierLike();
+    }
+};
 
 pub const ParseVariableDeclarationOpts = struct {
     await_using: bool = false,
@@ -200,7 +208,18 @@ pub fn parseVariableDeclarator(
 /// returns `true` when `tag` can begin a `BindingIdentifier` or destructuring
 /// pattern, i.e. the head of a variable declarator.
 pub fn canStartBinding(tag: TokenTag) bool {
+    if (dialectCanStartBinding(tag)) |value| return value;
     return tag.isIdentifierLike() or tag == .left_bracket or tag == .left_brace;
+}
+
+fn dialectCanStartBinding(tag: TokenTag) ?bool {
+    if (comptime dialect.enabled and @hasDecl(dialect, "can_start_binding")) {
+        switch (dialect.can_start_binding(DialectHost, tag)) {
+            .handled => |value| return value,
+            .unhandled => {},
+        }
+    }
+    return null;
 }
 
 /// non-reserved identifier-like tokens can begin a `BindingIdentifier`.
@@ -212,6 +231,7 @@ pub fn canStartBindingIdentifier(tag: TokenTag) bool {
 /// can never bind, so `let in obj` keeps `let` as an identifier instead of
 /// committing to a declaration that cannot parse.
 pub fn canStartLetBinding(tag: TokenTag) bool {
+    if (dialectCanStartBinding(tag)) |value| return value;
     return tag == .left_bracket or tag == .left_brace or canStartBindingIdentifier(tag);
 }
 

--- a/src/parser/testing/cases/jsx_recovery.zig
+++ b/src/parser/testing/cases/jsx_recovery.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const parser = @import("parser");
+
+const testing = std.testing;
+
+// loose parsing keeps the parent close available while preserving source boundaries
+test "loose JSX parsing recovers a nested element closed by its parent" {
+    const source = "const view = <div>{/* kept */}<span>text</div>;";
+
+    var strict_tree = try parser.parse(testing.allocator, source, .{ .lang = .tsx });
+    defer strict_tree.deinit();
+
+    try testing.expectEqual(@as(usize, 1), strict_tree.diagnostics.items.len);
+    try testing.expectEqualStrings(
+        "Expected closing tag for '<span>' but found '</div>'",
+        strict_tree.diagnostics.items[0].message,
+    );
+
+    var loose_tree = try parser.parse(testing.allocator, source, .{
+        .lang = .tsx,
+        .loose = true,
+    });
+    defer loose_tree.deinit();
+
+    try testing.expectEqual(@as(usize, 0), loose_tree.diagnostics.items.len);
+    try testing.expectEqual(@as(usize, 1), loose_tree.comments.len);
+    try testing.expectEqual(@as(u32, 19), loose_tree.comments[0].span.start);
+    try testing.expectEqual(@as(u32, 29), loose_tree.comments[0].span.end);
+
+    var child: ?parser.ast.NodeIndex = null;
+    var parent: ?parser.ast.NodeIndex = null;
+    var index_value: u32 = 0;
+    while (index_value < loose_tree.nodes.len) : (index_value += 1) {
+        const index: parser.ast.NodeIndex = @enumFromInt(index_value);
+        if (loose_tree.data(index) != .jsx_element) continue;
+
+        const span = loose_tree.span(index);
+        if (span.start == 30) child = index;
+        if (span.start == 13) parent = index;
+    }
+
+    const child_index = child orelse return error.MissingRecoveredChild;
+    const parent_index = parent orelse return error.MissingParent;
+    try testing.expectEqual(@as(u32, 30), loose_tree.span(child_index).start);
+    try testing.expectEqual(@as(u32, 40), loose_tree.span(child_index).end);
+    try testing.expectEqual(
+        parser.ast.NodeIndex.null,
+        loose_tree.data(child_index).jsx_element.closing_element,
+    );
+    try testing.expect(loose_tree.data(parent_index).jsx_element.closing_element != .null);
+    try testing.expectEqual(@as(u32, 46), loose_tree.span(parent_index).end);
+}

--- a/src/parser/testing/cases/jsx_recovery.zig
+++ b/src/parser/testing/cases/jsx_recovery.zig
@@ -50,3 +50,26 @@ test "loose JSX parsing recovers a nested element closed by its parent" {
     try testing.expect(loose_tree.data(parent_index).jsx_element.closing_element != .null);
     try testing.expectEqual(@as(u32, 46), loose_tree.span(parent_index).end);
 }
+
+test "JSX EOF diagnostic is preserved in default and loose modes" {
+    const source = "<foo>yes";
+    const message = "Expected '</' to close the JSX element, but found 'end of file'";
+    const help = "Add a closing tag to match the opening element";
+
+    var default_tree = try parser.parse(testing.allocator, source, .{ .lang = .jsx });
+    defer default_tree.deinit();
+
+    try testing.expectEqual(@as(usize, 1), default_tree.diagnostics.items.len);
+    try testing.expectEqualStrings(message, default_tree.diagnostics.items[0].message);
+    try testing.expectEqualStrings(help, default_tree.diagnostics.items[0].help orelse "");
+
+    var loose_tree = try parser.parse(testing.allocator, source, .{
+        .lang = .jsx,
+        .loose = true,
+    });
+    defer loose_tree.deinit();
+
+    try testing.expectEqual(@as(usize, 1), loose_tree.diagnostics.items.len);
+    try testing.expectEqualStrings(message, loose_tree.diagnostics.items[0].message);
+    try testing.expectEqualStrings(help, loose_tree.diagnostics.items[0].help orelse "");
+}

--- a/src/parser/testing/dialect.zig
+++ b/src/parser/testing/dialect.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+const parser = @import("parser");
+const transfer = @import("transfer");
+
+const base_node_variants_expected: u16 = 171;
+
+test "disabled dialect preserves layout and allocates no storage" {
+    var tree = parser.ast.Tree.initEmpty(std.testing.allocator);
+    defer tree.deinit();
+
+    try std.testing.expectEqual(@as(usize, 44), @sizeOf(parser.ast.NodeData));
+    try std.testing.expectEqual(@as(usize, 52), @sizeOf(parser.ast.Node));
+    try std.testing.expectEqual(@as(usize, 0), @sizeOf(parser.dialect_schema.Record));
+    try std.testing.expectEqual(@as(usize, 0), tree.arena.queryCapacity());
+    try std.testing.expectEqual(@as(?u32, null), tree.dialectOverlay(0));
+    try std.testing.expectEqual(@as(usize, 0), tree.arena.queryCapacity());
+    std.debug.print("disabled layout: node_data={d} node={d} tree={d} store={d}\n", .{
+        @sizeOf(parser.ast.NodeData),
+        @sizeOf(parser.ast.Node),
+        @sizeOf(parser.ast.Tree),
+        @sizeOf(parser.dialect_schema.Record),
+    });
+}
+
+test "disabled dialect wire remains deterministic" {
+    const source = "export const value: number = <Box answer={42} />;";
+    var tree = try parser.parse(std.testing.allocator, source, .{ .lang = .tsx });
+    defer tree.deinit();
+    try std.testing.expect(!tree.hasErrors());
+
+    const bytes = try std.testing.allocator.alloc(u8, transfer.bufferSize(&tree));
+    defer std.testing.allocator.free(bytes);
+    try std.testing.expectEqual(bytes.len, transfer.serializeInto(&tree, bytes));
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    std.debug.print("disabled wire: bytes={d} sha256={x}\n", .{ bytes.len, digest });
+}
+
+test "disabled corpus behavior is deterministic" {
+    const Case = struct { source: []const u8, lang: parser.ast.Lang };
+    const cases = [_]Case{
+        .{ .source = "@dec class C {}", .lang = .ts },
+        .{ .source = "const x = @dec class {};", .lang = .ts },
+        .{ .source = "!value;", .lang = .js },
+        .{ .source = "function f() {}", .lang = .js },
+        .{ .source = "for (value of values) {}", .lang = .js },
+        .{ .source = "let value = 1;", .lang = .js },
+        .{ .source = "import value from package;", .lang = .js },
+        .{ .source = "declare const value: number;", .lang = .ts },
+        .{ .source = "const x = <A>left@right{value}</B>;", .lang = .tsx },
+        .{ .source = "import value from ;", .lang = .js },
+    };
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    for (cases) |case| {
+        var tree = try parser.parse(std.testing.allocator, case.source, .{ .lang = case.lang });
+        defer tree.deinit();
+        const bytes = try std.testing.allocator.alloc(u8, transfer.bufferSize(&tree));
+        defer std.testing.allocator.free(bytes);
+        _ = transfer.serializeInto(&tree, bytes);
+        hasher.update(bytes);
+        const diagnostics: u64 = tree.diagnostics.items.len;
+        hasher.update(std.mem.asBytes(&diagnostics));
+    }
+    var digest: [32]u8 = undefined;
+    hasher.final(&digest);
+    std.debug.print("unhandled corpus sha256={x}\n", .{digest});
+}
+
+test "derive base node variants and transfer capacity" {
+    // reflect the source union and packing rules instead of copying schema counts
+    const fields = @typeInfo(parser.ast.NodeData).@"union".fields;
+    const base_node_variants = comptime deriveBaseNodeVariants(fields);
+    const maxima = comptime maxima: {
+        @setEvalBranchQuota(10_000);
+        break :maxima deriveMaxima(fields[0..base_node_variants]);
+    };
+
+    try std.testing.expectEqual(base_node_variants_expected, base_node_variants);
+    try std.testing.expect(maxima.slots <= 7);
+    try std.testing.expect(maxima.flags <= 16);
+    try expectLayout(parser.ast.ForOfStatement, 3, 1);
+    try expectLayout(parser.ast.CatchClause, 2, 0);
+    try expectLayout(parser.ast.ArrayPattern, 4, 1);
+    try expectLayout(parser.ast.ObjectPattern, 4, 1);
+    std.debug.print("dialect capacity: base={d} slots_max={d} flags_max={d}\n", .{
+        base_node_variants,
+        maxima.slots,
+        maxima.flags,
+    });
+}
+
+fn deriveBaseNodeVariants(comptime fields: []const std.builtin.Type.UnionField) u16 {
+    std.debug.assert(fields.len > 0);
+    std.debug.assert(fields.len <= 256);
+    for (fields, 0..) |field, index| {
+        if (std.mem.eql(u8, field.name, "dialect_node")) return @intCast(index);
+    }
+    return @intCast(fields.len);
+}
+
+fn deriveMaxima(comptime fields: []const std.builtin.Type.UnionField) struct {
+    slots: u8,
+    flags: u8,
+} {
+    std.debug.assert(fields.len > 0);
+    std.debug.assert(fields.len <= 256);
+    var slots: u8 = 0;
+    var flags: u8 = 0;
+    for (fields) |field| {
+        if (@typeInfo(field.type) != .@"struct") continue;
+        slots = @max(slots, transfer.totalU32Slots(field.type));
+        flags = @max(flags, transfer.totalFlagBits(field.type));
+    }
+    return .{ .slots = slots, .flags = flags };
+}
+
+fn expectLayout(comptime T: type, slots_expected: u8, flags_expected: u8) !void {
+    std.debug.assert(@typeInfo(T) == .@"struct");
+    std.debug.assert(slots_expected <= 7);
+    const slots_actual = comptime transfer.totalU32Slots(T);
+    const flags_actual = comptime transfer.totalFlagBits(T);
+    try std.testing.expectEqual(slots_expected, slots_actual);
+    try std.testing.expectEqual(flags_expected, flags_actual);
+}

--- a/src/parser/testing/dialect.zig
+++ b/src/parser/testing/dialect.zig
@@ -64,6 +64,38 @@ test "disabled dialect transfer round-trip preserves bytes" {
     try std.testing.expectEqual(bytes.len, restored_bytes.len);
 }
 
+test "wire transfer pads diagnostic tail to u32 boundary" {
+    // prove complete transfers stay word-addressable when diagnostics end off-boundary
+    const source = "let value = 1;";
+    var tree = try parser.parse(std.testing.allocator, source, .{ .lang = .js });
+    defer tree.deinit();
+    try std.testing.expect(!tree.hasErrors());
+    try tree.addDiagnostic(.{
+        .severity = .warning,
+        .message = "x",
+        .span = .{ .start = 0, .end = 1 },
+    });
+
+    const bytes = try std.testing.allocator.alloc(u8, transfer.bufferSize(&tree));
+    defer std.testing.allocator.free(bytes);
+    @memset(bytes, 0xaa);
+    try std.testing.expectEqual(bytes.len, transfer.serializeInto(&tree, bytes));
+    try std.testing.expectEqual(@as(usize, 0), bytes.len % @sizeOf(u32));
+
+    const diagnostic_size = 1 + 4 + 4 + 4 + 1 + 1 + 4;
+    const padding_len = (@sizeOf(u32) - diagnostic_size % @sizeOf(u32)) % @sizeOf(u32);
+    try std.testing.expectEqual(@as(usize, 1), padding_len);
+    for (bytes[bytes.len - padding_len ..]) |byte| {
+        try std.testing.expectEqual(@as(u8, 0), byte);
+    }
+
+    var restored = try transfer.deserializeFromBuf(std.testing.allocator, bytes, source);
+    defer restored.deinit();
+    try std.testing.expectEqual(tree.root, restored.root);
+    try std.testing.expectEqual(tree.nodes.len, restored.nodes.len);
+    try std.testing.expect(restored.data(restored.root) == .program);
+}
+
 test "disabled corpus behavior is deterministic" {
     const Case = struct { source: []const u8, lang: parser.ast.Lang };
     const cases = [_]Case{

--- a/src/parser/testing/dialect.zig
+++ b/src/parser/testing/dialect.zig
@@ -36,6 +36,34 @@ test "disabled dialect wire remains deterministic" {
     std.debug.print("disabled wire: bytes={d} sha256={x}\n", .{ bytes.len, digest });
 }
 
+// round-trip transfer instantiates disabled record decoding without dialect storage
+test "disabled dialect transfer round-trip preserves bytes" {
+    const source = "export const value: number = <Box answer={42} />;";
+    var tree = try parser.parse(std.testing.allocator, source, .{ .lang = .tsx });
+    defer tree.deinit();
+    try std.testing.expect(!tree.hasErrors());
+
+    const bytes = try std.testing.allocator.alloc(u8, transfer.bufferSize(&tree));
+    defer std.testing.allocator.free(bytes);
+    try std.testing.expectEqual(bytes.len, transfer.serializeInto(&tree, bytes));
+
+    var restored = try transfer.deserializeFromBuf(std.testing.allocator, bytes, source);
+    defer restored.deinit();
+    try std.testing.expectEqual(tree.root, restored.root);
+    try std.testing.expectEqual(tree.nodes.len, restored.nodes.len);
+    try std.testing.expect(restored.data(restored.root) == .program);
+    try std.testing.expectEqual(@as(usize, 0), @sizeOf(@TypeOf(restored.dialect_store)));
+    try std.testing.expectEqual(@as(?u32, null), restored.dialectOverlay(0));
+
+    const restored_bytes = try std.testing.allocator.alloc(u8, transfer.bufferSize(&restored));
+    defer std.testing.allocator.free(restored_bytes);
+    try std.testing.expectEqual(
+        restored_bytes.len,
+        transfer.serializeInto(&restored, restored_bytes),
+    );
+    try std.testing.expectEqual(bytes.len, restored_bytes.len);
+}
+
 test "disabled corpus behavior is deterministic" {
     const Case = struct { source: []const u8, lang: parser.ast.Lang };
     const cases = [_]Case{

--- a/src/parser/testing/root.zig
+++ b/src/parser/testing/root.zig
@@ -6,4 +6,5 @@ test {
     _ = @import("cases/symbol.zig");
     _ = @import("cases/module_record.zig");
     _ = @import("cases/corpus.zig");
+    _ = @import("cases/jsx_recovery.zig");
 }

--- a/src/parser/traverser/walk.zig
+++ b/src/parser/traverser/walk.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const ast = @import("../ast.zig");
+const dialect = @import("dialect");
 
 const Allocator = std.mem.Allocator;
 
@@ -49,10 +50,15 @@ fn walkNode(
     else
         ctx.tree.data(index);
 
-    const result = if (action == .proceed)
-        try walkChildren(C, V, visitor, current, ctx)
-    else
-        Action.proceed;
+    var result = Action.proceed;
+    if (action == .proceed) {
+        result = try walkChildren(C, V, visitor, current, ctx);
+        if (comptime dialect.enabled) if (result != .stop) {
+            if (ctx.tree.dialectOverlay(@intFromEnum(index))) |record_index| {
+                result = try walkDialectRecord(C, V, visitor, record_index, ctx);
+            }
+        };
+    }
 
     // exits pair with enters unconditionally, they run when children
     // were skipped and while a stop unwinds, so tracking contexts
@@ -70,6 +76,16 @@ fn walkChildren(
     ctx: *C,
 ) Allocator.Error!Action {
     switch (data) {
+        .dialect_node => |node| {
+            if (comptime !dialect.enabled) {
+                comptime std.debug.assert(@typeInfo(dialect.Store).@"struct".fields.len == 0);
+                comptime std.debug.assert(@sizeOf(dialect.Store) == 0);
+                return .proceed;
+            }
+            std.debug.assert(ctx.tree.dialect_store.records.items.len > 0);
+            std.debug.assert(node.record_index < ctx.tree.dialect_store.records.items.len);
+            return walkDialectRecord(C, V, visitor, node.record_index, ctx);
+        },
         inline else => |node| {
             const T = @TypeOf(node);
             if (@typeInfo(T) == .@"struct") {
@@ -78,6 +94,80 @@ fn walkChildren(
             return .proceed;
         },
     }
+}
+
+fn walkDialectRecord(
+    comptime C: type,
+    comptime V: type,
+    visitor: *V,
+    record_index: u32,
+    ctx: *C,
+) Allocator.Error!Action {
+    std.debug.assert(ctx.tree.dialect_store.records.items.len > 0);
+    std.debug.assert(record_index < ctx.tree.dialect_store.records.items.len);
+    const record = ctx.tree.dialect_store.records.items[record_index];
+    switch (record) {
+        inline else => |payload| return walkDialectFields(C, V, visitor, payload, ctx),
+    }
+}
+
+fn walkDialectFields(
+    comptime C: type,
+    comptime V: type,
+    visitor: *V,
+    payload: anytype,
+    ctx: *C,
+) Allocator.Error!Action {
+    const T = @TypeOf(payload);
+    std.debug.assert(ctx.tree.nodes.len <= std.math.maxInt(u32));
+    std.debug.assert(ctx.tree.extras.items.len <= std.math.maxInt(u32));
+    inline for (@typeInfo(T).@"struct".fields) |field| {
+        if (comptime hasDialectRole(field.type)) {
+            const value = @field(payload, field.name);
+            switch (field.type.dialect_role) {
+                .node_ref => {
+                    std.debug.assert(value.raw != std.math.maxInt(u32));
+                    std.debug.assert(value.raw < ctx.tree.nodes.len);
+                    if ((try walkNode(C, V, visitor, @enumFromInt(value.raw), ctx)) == .stop)
+                        return .stop;
+                },
+                .optional_node_ref => {
+                    if (value.raw < ctx.tree.nodes.len) {
+                        if ((try walkNode(C, V, visitor, @enumFromInt(value.raw), ctx)) == .stop)
+                            return .stop;
+                    } else {
+                        std.debug.assert(value.raw == std.math.maxInt(u32));
+                        std.debug.assert(value.raw >= ctx.tree.nodes.len);
+                    }
+                },
+                .node_list => {
+                    std.debug.assert(value.start + value.len >= value.start);
+                    const end = value.start + value.len;
+                    std.debug.assert(end <= ctx.tree.extras.items.len);
+                    for (ctx.tree.extras.items[value.start..end]) |child| {
+                        if ((try walkNode(C, V, visitor, child, ctx)) == .stop) return .stop;
+                    }
+                },
+                .string_slice => {
+                    std.debug.assert(value.start <= value.end);
+                    std.debug.assert(value.end <= ctx.tree.source.len);
+                },
+                .overlay_host => {
+                    std.debug.assert(value.raw != std.math.maxInt(u32));
+                    std.debug.assert(value.raw < ctx.tree.nodes.len);
+                },
+                .scalar_u32 => {},
+            }
+        }
+    }
+    return .proceed;
+}
+
+fn hasDialectRole(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .@"struct", .@"enum", .@"union", .@"opaque" => @hasDecl(T, "dialect_role"),
+        else => false,
+    };
 }
 
 fn walkStructFields(

--- a/tools/estree/decoder.zig
+++ b/tools/estree/decoder.zig
@@ -23,6 +23,7 @@ pub fn generate(w: *Writer, mode: Mode) !void {
         \\
     );
     try writeLookupTables(w);
+    try writeDialectSchema(w);
     if (mode == .analyzer) try writeSemanticConstants(w);
     if (mode == .analyzer) try writeChildTables(w);
     try writeBuildPosMap(w);
@@ -33,6 +34,31 @@ pub fn generate(w: *Writer, mode: Mode) !void {
         .parser => try w.writeAll("export { decode };\n"),
         .analyzer => try w.writeAll("export { decode, SymbolFlags };\n"),
     }
+}
+
+fn writeDialectSchema(w: *Writer) !void {
+    if (comptime !parser.dialect_enabled) return;
+    comptime meta.validateDialectSchema();
+    try w.writeAll("const DIALECT_TS = Symbol.for(\"yuku.estree.transfer.ts\");\n");
+    try w.writeAll("const DIALECT_RECORDS = Object.freeze([\n");
+    inline for (@typeInfo(parser.dialect_schema.Record).@"union".fields, 0..) |record, index| {
+        try w.print("  Object.freeze({{ tag: {d}, type: \"{s}\", overlay: {}, fields: Object.freeze([", .{
+            comptime rt.dialectNodeTag() + 1 + index,
+            comptime meta.dialectRecordType(record.name, record.type),
+            comptime meta.dialectRecordIsOverlay(record.type),
+        });
+        inline for (std.meta.fields(record.type), 0..) |field, field_index| {
+            if (field_index > 0) try w.writeAll(", ");
+            try w.print("Object.freeze({{ name: \"{s}\", role: \"{s}\", slot: {d}, bit: {d} }})", .{
+                comptime meta.estreeField(record.name, field.name),
+                comptime meta.dialectRoleName(field.type),
+                comptime rt.u32SlotForField(record.type, field_index) + rt.NODE_HEADER_U32S,
+                comptime rt.flagBitForField(record.type, field_index),
+            });
+        }
+        try w.writeAll("]) }),\n");
+    }
+    try w.writeAll("]);\n");
 }
 
 const symbol_flag_names = [_]struct { zig: []const u8, js: []const u8 }{
@@ -180,6 +206,7 @@ fn writeBuildPosMap(w: *Writer) !void {
 fn writeDecodeOpen(w: *Writer) !void {
     try w.print(
         \\function decode(buffer, source) {{
+        \\{[dialect_guard]s}
         \\  const _u8 = new Uint8Array(buffer);
         \\  const _u32 = new Int32Array(buffer, 0, buffer.byteLength >> 2);
         \\  const _src = source;
@@ -232,7 +259,7 @@ fn writeDecodeOpen(w: *Writer) !void {
         \\    return r;
         \\  }}
         \\  const pm = _firstNa < _srcLen ? buildPosMap(_src, _srcLen, _firstNa) : null;
-        \\  const _p = v => v <= _firstNa ? v : pm[v - _firstNa];
+        \\  const _p = {[position_expr]s};
         \\  const str = (s, e) => {{
         \\    if (s === e) return "";
         \\    if (s >= _srcLen) return _poolDecode(s, e);
@@ -287,6 +314,14 @@ fn writeDecodeOpen(w: *Writer) !void {
         ),
         .items = comptime u32IndexOf(ast.FormalParameters, "items"),
         .rest = comptime u32IndexOf(ast.FormalParameters, "rest"),
+        .dialect_guard = if (comptime parser.dialect_enabled)
+            comptime std.fmt.comptimePrint("  if (buffer.byteLength < {d} || (buffer.byteLength & 3)) throw new RangeError(\"yuku: malformed transfer buffer\");", .{rt.HEADER_SIZE})
+        else
+            "",
+        .position_expr = if (comptime parser.dialect_enabled)
+            "v => !pm || v <= _firstNa ? v : pm[v - _firstNa]"
+        else
+            "v => v <= _firstNa ? v : pm[v - _firstNa]",
     });
 }
 
@@ -333,8 +368,8 @@ fn writeNodeFunction(w: *Writer, mode: Mode) !void {
         \\    const tag = h0 & 255;
         \\    const flags = {[fe]s};
         \\    const _ss = _u32[b + {[ss]d}], _se = _u32[b + {[se]d}];
-        \\    const start = _ss <= _firstNa ? _ss : pm[_ss - _firstNa];
-        \\    const end = _se <= _firstNa ? _se : pm[_se - _firstNa];
+        \\    const start = {[start_expr]s};
+        \\    const end = {[end_expr]s};
         \\    switch (tag) {{
         \\
     , .{
@@ -346,16 +381,46 @@ fn writeNodeFunction(w: *Writer, mode: Mode) !void {
         .fe = flags_expr,
         .ss = rt.NODE_SPAN_START_U32,
         .se = rt.NODE_SPAN_END_U32,
+        .start_expr = if (comptime parser.dialect_enabled)
+            "_p(_ss)"
+        else
+            "_ss <= _firstNa ? _ss : pm[_ss - _firstNa]",
+        .end_expr = if (comptime parser.dialect_enabled)
+            "_p(_se)"
+        else
+            "_se <= _firstNa ? _se : pm[_se - _firstNa]",
     });
     try writeNodeCases(w);
     switch (mode) {
-        .parser => try w.writeAll(
+        .parser => if (comptime parser.dialect_enabled) try w.writeAll(
+            \\    }
+            \\  }
+            \\  const _baseNode = _attached ? nodeWithComments : _decode;
+            \\  function node(i) { return applyDialectOverlay(i, _baseNode(i)); }
+            \\
+        ) else try w.writeAll(
             \\    }
             \\  }
             \\  const node = _attached ? nodeWithComments : _decode;
             \\
         ),
-        .analyzer => try w.writeAll(
+        .analyzer => if (comptime parser.dialect_enabled) try w.writeAll(
+            \\    }
+            \\  }
+            \\  const _baseInner = _attached ? nodeWithComments : _decode;
+            \\  const _inner = i => applyDialectOverlay(i, _baseInner(i));
+            \\  const _nodes = Array.from({ length: nodeCount });
+            \\  const _nodeIndexes = new WeakMap();
+            \\  function node(i) {
+            \\    const m = _nodes[i];
+            \\    if (m !== undefined) return m;
+            \\    const r = _inner(i);
+            \\    _nodes[i] = r;
+            \\    if (r !== null && typeof r === "object" && !_nodeIndexes.has(r)) _nodeIndexes.set(r, i);
+            \\    return r;
+            \\  }
+            \\
+        ) else try w.writeAll(
             \\    }
             \\  }
             \\  const _inner = _attached ? nodeWithComments : _decode;
@@ -517,6 +582,7 @@ pub fn generateWalkTables(w: *Writer) !void {
         \\
     );
     inline for (@typeInfo(ast.NodeData).@"union".fields) |field| {
+        if (comptime !meta.includeNode(field.name)) continue;
         if (comptime specialChildKeysOf(field.name)) |entry| {
             inline for (entry.types) |t| {
                 try w.print("ck(\"{s}\", [", .{t});
@@ -550,6 +616,7 @@ pub fn generateWalkTables(w: *Writer) !void {
         \\
     );
     inline for (@typeInfo(ast.NodeData).@"union".fields) |field| {
+        if (comptime !meta.includeNode(field.name)) continue;
         if (comptime specialChildKeysOf(field.name)) |entry| {
             inline for (entry.types) |t| {
                 try w.print("  \"{s}\",\n", .{t});
@@ -575,6 +642,7 @@ fn writeChildTables(w: *Writer) !void {
     //        2 range with length in field0, 3 range with length in field0b
     try w.writeAll("const CHILD_SLOTS = [\n");
     inline for (@typeInfo(ast.NodeData).@"union".fields) |field| {
+        if (comptime !meta.includeNode(field.name)) continue;
         try w.writeAll("  [");
         if (@typeInfo(field.type) == .@"struct") {
             comptime var first = true;
@@ -602,6 +670,7 @@ fn writeChildTables(w: *Writer) !void {
 
     try w.writeAll("const IS_NODE = [\n");
     inline for (@typeInfo(ast.NodeData).@"union".fields) |field| {
+        if (comptime !meta.includeNode(field.name)) continue;
         const materialized = comptime if (specialChildKeysOf(field.name)) |entry|
             entry.types.len != 0
         else
@@ -680,6 +749,7 @@ fn writeNodeCases(w: *Writer) !void {
     @setEvalBranchQuota(100_000);
     var body_buf: [16 * 1024]u8 = undefined;
     inline for (@typeInfo(ast.NodeData).@"union".fields, 0..) |field, tag| {
+        if (comptime !meta.includeNode(field.name)) continue;
         var body_w: Writer = .fixed(&body_buf);
         if (comptime isSpecial(field.name)) {
             try writeSpecialCase(&body_w, field.name);
@@ -698,6 +768,10 @@ fn writeGenericCase(
     comptime name: []const u8,
     comptime T: type,
 ) !void {
+    if (comptime std.mem.eql(u8, name, "dialect_node")) {
+        try w.writeAll("return dialectRecord(f1, start, end, false);");
+        return;
+    }
     const etype = comptime meta.estreeType(name);
     const has_ts = comptime hasAnyTsField(name, T) or tsExtrasOf(name).len > 0;
     if (!has_ts) {
@@ -747,7 +821,9 @@ fn writeFieldExpr(
     comptime F: type,
 ) !void {
     const s = comptime rt.u32SlotForField(T, i) + 1;
-    if (F == ast.NodeIndex) {
+    if (F == u32) {
+        try w.print("f{d}", .{s});
+    } else if (F == ast.NodeIndex) {
         try w.print("f{d} !== NULL ? node(f{d}) : null", .{ s, s });
     } else if (F == ast.IndexRange) {
         const fn_name = comptime if (meta.isHoleyArray(tag_name, field_name)) "nodeArrHoles" else "nodeArr";
@@ -825,12 +901,18 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8) !void {
             \\      return r;
         , .{
             comptime enumMask(ast.FunctionType),
-            sid, sid,
-            bg,  ba,
-            sp,  sp,
-            sb,  sb,
-            stp, stp,
-            srt, srt,
+            sid,
+            sid,
+            bg,
+            ba,
+            sp,
+            sp,
+            sb,
+            sb,
+            stp,
+            stp,
+            srt,
+            srt,
             bd,
         });
     } else if (comptime eql(u8, name, "arrow_function_expression")) {
@@ -858,7 +940,22 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8) !void {
         const sb = comptime slotOf(ast.Program, "body");
         const hs = comptime slotOf(ast.Program, "hashbang");
         // hashbang span includes the leading #!, so its start is value.start minus 2
-        try emit(w,
+        if (comptime parser.dialect_enabled) try emit(w,
+            \\const r = {{
+            \\      type: "Program", start, end,
+            \\      sourceType: (flags & 1) ? "module" : "script",
+            \\      hashbang: (flags & {d}) ? {{
+            \\        type: "Hashbang",
+            \\        start: _p(f{d} - 2), end: _p(f{d}),
+            \\        value: str(f{d}, f{d}),
+            \\      }} : null,
+            \\      body: nodeArr(f{d}, f0),
+            \\    }};
+            \\      if (_isTs) Object.defineProperty(r, DIALECT_TS, {{
+            \\        value: true, enumerable: false, writable: false, configurable: false,
+            \\      }});
+            \\      return r;
+        , .{ comptime flagMask(ast.Program, "hashbang"), hs, hs + 1, hs, hs + 1, sb }) else try emit(w,
             \\return {{
             \\      type: "Program", start, end,
             \\      sourceType: (flags & 1) ? "module" : "script",
@@ -989,13 +1086,19 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8) !void {
             \\      return r;
         , .{
             comptime enumMask(ast.ClassType),
-            sd,                                       si,
-            si,                                       ss,
-            ss,                                       sb,
-            stp,                                      stp,
-            ssta,                                     ssta,
+            sd,
+            si,
+            si,
+            ss,
+            ss,
+            sb,
+            stp,
+            stp,
+            ssta,
+            ssta,
             simp,
-            comptime flagMask(ast.Class, "abstract"), comptime flagMask(ast.Class, "declare"),
+            comptime flagMask(ast.Class, "abstract"),
+            comptime flagMask(ast.Class, "declare"),
         });
     } else if (comptime eql(u8, name, "method_definition")) {
         const M = ast.MethodDefinition;
@@ -1131,10 +1234,10 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8) !void {
             \\      }}
             \\      return r;
         , .{
-            se,  sr,
-            sr,  sdec,
-            comptime flagMask(ast.ArrayPattern, "optional"),
-            sta, sta,
+            se,                                              sr,
+            sr,                                              sdec,
+            comptime flagMask(ast.ArrayPattern, "optional"), sta,
+            sta,
         });
     } else if (comptime eql(u8, name, "object_pattern")) {
         const sp = comptime slotOf(ast.ObjectPattern, "properties");
@@ -1153,10 +1256,10 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8) !void {
             \\      }}
             \\      return r;
         , .{
-            sp,  sr,
-            sr,  sdec,
-            comptime flagMask(ast.ObjectPattern, "optional"),
-            sta, sta,
+            sp,                                               sr,
+            sr,                                               sdec,
+            comptime flagMask(ast.ObjectPattern, "optional"), sta,
+            sta,
         });
     } else if (comptime eql(u8, name, "jsx_text")) {
         const sv = comptime slotOf(ast.JSXText, "value");
@@ -1307,8 +1410,168 @@ fn writeSpecialCase(w: *Writer, comptime name: []const u8) !void {
 fn writeDecodeBody(w: *Writer, mode: Mode) !void {
     comptime std.debug.assert(rt.COMMENT_FLAGS_OFFSET == 0);
     comptime std.debug.assert(rt.COMMENT_SIZE % 4 == 0);
-    try w.print(
+    if (comptime parser.dialect_enabled) try w.print(
+        \\  const _dialectSectionOff = _cOff + commentCount * {[csize]d};
+        \\  const _hasDialectRecords = !!(_flags & {[flag]d});
+        \\  const _dialectRecordCount = _hasDialectRecords ? _u32[_dialectSectionOff >> 2] : 0;
+        \\  const _dialectOverlayCount = _hasDialectRecords ? _u32[(_dialectSectionOff >> 2) + 1] : 0;
+        \\  const _dialectRecordsOff = _dialectSectionOff + (_hasDialectRecords ? {[sub]d} : 0);
+        \\  const _dialectOverlaysOff = _dialectRecordsOff + _dialectRecordCount * {[node_size]d};
+        \\  const dOff = _dialectOverlaysOff + _dialectOverlayCount * {[overlay_size]d};
+        \\  const _dialectActive = new Set();
+        \\  function dialectRecord(ri, start, end, overlay) {{
+        \\    if (ri < 0 || ri >= _dialectRecordCount) throw new RangeError("yuku: dialect record index out of bounds");
+        \\    if (_dialectActive.has(ri)) throw new RangeError("yuku: cyclic dialect record");
+        \\    _dialectActive.add(ri);
+        \\    try {{
+        \\      const b = (_dialectRecordsOff >> 2) + ri * ({[node_size]d} >> 2);
+        \\      const packedTag = _u32[b] & 255;
+        \\      const schema = DIALECT_RECORDS[packedTag - DIALECT_RECORDS[0].tag];
+        \\      if (!schema || schema.tag !== packedTag || schema.overlay !== overlay)
+        \\        throw new RangeError("yuku: invalid dialect record tag");
+        \\      const r = overlay ? {{}} : {{ type: schema.type, start, end }};
+        \\      const packedFlags = _u32[b] >>> 16;
+        \\      for (const field of schema.fields) {{
+        \\        if (field.role === "host") continue;
+        \\        const v = _u32[b + field.slot];
+        \\        if (field.role === "bool") r[field.name] = !!(packedFlags & (1 << field.bit));
+        \\        else if (field.role === "scalar") r[field.name] = v >>> 0;
+        \\        else if (field.role === "node") r[field.name] = node(v);
+        \\        else if (field.role === "optionalNode") r[field.name] = v === NULL ? null : node(v);
+        \\        else if (field.role === "nodeList") r[field.name] = nodeArr(v, _u32[b + field.slot + 1]);
+        \\        else if (field.role === "string") r[field.name] = str(v, _u32[b + field.slot + 1]);
+        \\      }}
+        \\      return r;
+        \\    }} finally {{ _dialectActive.delete(ri); }}
+        \\  }}
+        \\  function applyDialectOverlay(i, r) {{
+        \\    if (!_hasDialectRecords || r == null || typeof r !== "object") return r;
+        \\    let lo = 0, hi = _dialectOverlayCount;
+        \\    const base = _dialectOverlaysOff >> 2;
+        \\    while (lo < hi) {{ const m = (lo + hi) >>> 1; if (_u32[base + m * 2] < i) lo = m + 1; else hi = m; }}
+        \\    if (lo < _dialectOverlayCount && _u32[base + lo * 2] === i)
+        \\      Object.assign(r, dialectRecord(_u32[base + lo * 2 + 1], r.start, r.end, true));
+        \\    return r;
+        \\  }}
+        \\
+    , .{ .csize = rt.COMMENT_SIZE, .flag = rt.FLAG_DIALECT_RECORDS, .sub = rt.DIALECT_SUBHEADER_SIZE, .node_size = rt.NODE_SIZE, .overlay_size = rt.DIALECT_OVERLAY_SIZE });
+    if (comptime parser.dialect_enabled) try w.print(
+        \\  function _validNodeIndex(v) {{ return Number.isInteger(v) && v >= 0 && v < nodeCount; }}
+        \\  function _validateDialectSection() {{
+        \\    for (const count of [nodeCount, extraCount, spLen, commentCount, attachedCommentCount, diagCount])
+        \\      if (!Number.isInteger(count) || count < 0) throw new RangeError("yuku: invalid section count");
+        \\    if (!_validNodeIndex(progIdx)) throw new RangeError("yuku: invalid program index");
+        \\    const checked = (start, count, size) => {{
+        \\      const end = start + count * size;
+        \\      if (!Number.isSafeInteger(end) || end < start || end > buffer.byteLength)
+        \\        throw new RangeError("yuku: invalid section extent");
+        \\      return end;
+        \\    }};
+        \\    let end = checked({[header]d}, nodeCount, {[node_size]d});
+        \\    end = checked(end, extraCount, 4);
+        \\    end = checked(end, (spLen + 3) & ~3, 1);
+        \\    if (_attached) end = checked(end, nodeCount + 1, 4);
+        \\    end = checked(end, attachedCommentCount, {[attached_size]d});
+        \\    end = checked(end, commentCount, {[comment_size]d});
+        \\    if (end !== _dialectSectionOff) throw new RangeError("yuku: inconsistent dialect offset");
+        \\    if (!_hasDialectRecords) {{
+        \\      for (let i = 0; i < nodeCount; i++)
+        \\        if (_u8[_nodesOff + i * {[node_size]d}] === {[dialect_tag]d}) throw new RangeError("yuku: missing dialect section");
+        \\      return;
+        \\    }}
+        \\    if (!Number.isInteger(_dialectRecordCount) || _dialectRecordCount <= 0 ||
+        \\        !Number.isInteger(_dialectOverlayCount) || _dialectOverlayCount < 0)
+        \\      throw new RangeError("yuku: non-canonical dialect counts");
+        \\    end = checked(_dialectSectionOff, 1, {[sub]d});
+        \\    end = checked(end, _dialectRecordCount, {[node_size]d});
+        \\    end = checked(end, _dialectOverlayCount, {[overlay_size]d});
+        \\    if (end !== dOff) throw new RangeError("yuku: inconsistent dialect extent");
+        \\    const schemas = new Array(_dialectRecordCount);
+        \\    const poolLimit = _srcLen + spLen;
+        \\    for (let ri = 0; ri < _dialectRecordCount; ri++) {{
+        \\      const b = (_dialectRecordsOff >> 2) + ri * ({[node_size]d} >> 2);
+        \\      const tag = _u32[b] & 255;
+        \\      const schema = DIALECT_RECORDS[tag - DIALECT_RECORDS[0].tag];
+        \\      if (!schema || schema.tag !== tag) throw new RangeError("yuku: invalid unused dialect tag");
+        \\      schemas[ri] = schema;
+        \\      for (const field of schema.fields) {{
+        \\        const v = _u32[b + field.slot], uv = v >>> 0;
+        \\        if ((field.role === "node" || field.role === "host") && !_validNodeIndex(v))
+        \\          throw new RangeError("yuku: dialect node role out of bounds");
+        \\        if (field.role === "optionalNode" && v !== NULL && !_validNodeIndex(v))
+        \\          throw new RangeError("yuku: optional dialect node out of bounds");
+        \\        if (field.role === "nodeList") {{
+        \\          const len = _u32[b + field.slot + 1] >>> 0;
+        \\          if (uv + len > extraCount || uv + len < uv) throw new RangeError("yuku: dialect list out of bounds");
+        \\          for (let j = 0; j < len; j++) if (!_validNodeIndex(_u32[_extraBase + uv + j]))
+        \\            throw new RangeError("yuku: dialect list node out of bounds");
+        \\        }}
+        \\        if (field.role === "string") {{
+        \\          const e = _u32[b + field.slot + 1] >>> 0;
+        \\          if (uv > e || (uv < _srcLen ? e > _srcLen : e > poolLimit))
+        \\            throw new RangeError("yuku: dialect string out of bounds");
+        \\        }}
+        \\      }}
+        \\    }}
+        \\    for (let i = 0; i < nodeCount; i++) {{
+        \\      const b = ({[header]d} >> 2) + i * ({[node_size]d} >> 2);
+        \\      if ((_u32[b] & 255) !== {[dialect_tag]d}) continue;
+        \\      const ri = _u32[b + {[data_start]d}];
+        \\      if (ri < 0 || ri >= _dialectRecordCount || schemas[ri].overlay)
+        \\        throw new RangeError("yuku: invalid direct dialect record use");
+        \\    }}
+        \\    let previousHost = -1;
+        \\    const overlayBase = _dialectOverlaysOff >> 2;
+        \\    for (let i = 0; i < _dialectOverlayCount; i++) {{
+        \\      const host = _u32[overlayBase + i * 2], ri = _u32[overlayBase + i * 2 + 1];
+        \\      if (!_validNodeIndex(host) || host <= previousHost || ri < 0 || ri >= _dialectRecordCount || !schemas[ri].overlay)
+        \\        throw new RangeError("yuku: invalid dialect overlay");
+        \\      const hostField = schemas[ri].fields.find(field => field.role === "host");
+        \\      const rb = (_dialectRecordsOff >> 2) + ri * ({[node_size]d} >> 2);
+        \\      if (!hostField || _u32[rb + hostField.slot] !== host) throw new RangeError("yuku: overlay host mismatch");
+        \\      previousHost = host;
+        \\    }}
+        \\    const states = new Uint8Array(_dialectRecordCount);
+        \\    let visitRecord;
+        \\    const visitNodeIndex = value => {{
+        \\      if (!_validNodeIndex(value)) throw new RangeError("yuku: dialect cycle node out of bounds");
+        \\      const nb = ({[header]d} >> 2) + value * ({[node_size]d} >> 2);
+        \\      if ((_u32[nb] & 255) === {[dialect_tag]d}) visitRecord(_u32[nb + {[data_start]d}]);
+        \\    }};
+        \\    visitRecord = ri => {{
+        \\      if (ri < 0 || ri >= _dialectRecordCount) throw new RangeError("yuku: dangling dialect cycle edge");
+        \\      if (states[ri] === 1) throw new RangeError("yuku: cyclic dialect record");
+        \\      if (states[ri] === 2) return;
+        \\      states[ri] = 1;
+        \\      const schema = schemas[ri], b = (_dialectRecordsOff >> 2) + ri * ({[node_size]d} >> 2);
+        \\      for (const field of schema.fields) {{
+        \\        const v = _u32[b + field.slot];
+        \\        if (field.role === "node") visitNodeIndex(v);
+        \\        else if (field.role === "optionalNode" && v !== NULL) visitNodeIndex(v);
+        \\        else if (field.role === "nodeList") {{
+        \\          const start = v >>> 0, len = _u32[b + field.slot + 1] >>> 0;
+        \\          for (let j = 0; j < len; j++) visitNodeIndex(_u32[_extraBase + start + j]);
+        \\        }}
+        \\      }}
+        \\      states[ri] = 2;
+        \\    }};
+        \\    for (let ri = 0; ri < _dialectRecordCount; ri++) visitRecord(ri);
+        \\  }}
+        \\
+    , .{
+        .header = rt.HEADER_SIZE,
+        .node_size = rt.NODE_SIZE,
+        .attached_size = rt.ATTACHED_COMMENT_SIZE,
+        .comment_size = rt.COMMENT_SIZE,
+        .dialect_tag = rt.dialectNodeTag(),
+        .sub = rt.DIALECT_SUBHEADER_SIZE,
+        .overlay_size = rt.DIALECT_OVERLAY_SIZE,
+        .data_start = rt.NODE_HEADER_U32S,
+    });
+    if (comptime !parser.dialect_enabled) try w.print(
         \\  const dOff = _cOff + commentCount * {[csize]d};
+    , .{ .csize = rt.COMMENT_SIZE });
+    try w.print(
         \\  function _decodeComments() {{
         \\    const out = new Array(commentCount);
         \\    for (let j = 0; j < commentCount; j++) {{
@@ -1360,7 +1623,6 @@ fn writeDecodeBody(w: *Writer, mode: Mode) !void {
         \\  }}
         \\
     , .{
-        .csize = rt.COMMENT_SIZE,
         .c_stride = rt.COMMENT_SIZE / 4,
         .c_vs = rt.COMMENT_VALUE_START_OFFSET / 4,
         .c_ve = rt.COMMENT_VALUE_END_OFFSET / 4,
@@ -1373,6 +1635,7 @@ fn writeDecodeBody(w: *Writer, mode: Mode) !void {
         try writeSemanticBody(w);
     }
 
+    if (comptime parser.dialect_enabled) try w.writeAll("  _validateDialectSection();\n");
     try w.writeAll(
         \\  let _program, _diagnostics, _comments;
         \\  return {

--- a/tools/estree/encoder.zig
+++ b/tools/estree/encoder.zig
@@ -10,13 +10,40 @@ const Writer = std.Io.Writer;
 pub fn generate(w: *Writer) !void {
     @setEvalBranchQuota(500_000);
     try writePrologue(w);
+    try writeDialectSchema(w);
     try writeInverseMaps(w);
     try writeRuntime(w);
+    try writeDialectRuntime(w);
     try writeIdentifierHelpers(w);
     try writeNodeEncoders(w);
     try writeDispatcher(w);
     try writeAssemble(w);
     try w.writeAll("export { encode };\n");
+}
+
+fn writeDialectSchema(w: *Writer) !void {
+    if (comptime !parser.dialect_enabled) return;
+    comptime meta.validateDialectSchema();
+    try w.writeAll("const DIALECT_TS = Symbol.for(\"yuku.estree.transfer.ts\");\n");
+    try w.writeAll("const DIALECT_RECORDS = Object.freeze([\n");
+    inline for (@typeInfo(parser.dialect_schema.Record).@"union".fields, 0..) |record, index| {
+        try w.print("  Object.freeze({{ tag: {d}, type: \"{s}\", overlay: {}, fields: Object.freeze([", .{
+            comptime rt.dialectNodeTag() + 1 + index,
+            comptime meta.dialectRecordType(record.name, record.type),
+            comptime meta.dialectRecordIsOverlay(record.type),
+        });
+        inline for (std.meta.fields(record.type), 0..) |field, field_index| {
+            if (field_index > 0) try w.writeAll(", ");
+            try w.print("Object.freeze({{ name: \"{s}\", role: \"{s}\", slot: {d}, bit: {d} }})", .{
+                comptime meta.estreeField(record.name, field.name),
+                comptime meta.dialectRoleName(field.type),
+                comptime rt.u32SlotForField(record.type, field_index) + rt.NODE_HEADER_U32S,
+                comptime rt.flagBitForField(record.type, field_index),
+            });
+        }
+        try w.writeAll("]) }),\n");
+    }
+    try w.writeAll("]);\n");
 }
 
 fn writePrologue(w: *Writer) !void {
@@ -227,6 +254,69 @@ fn writeRuntime(w: *Writer) !void {
     );
 }
 
+fn writeDialectRuntime(w: *Writer) !void {
+    if (comptime !parser.dialect_enabled) return;
+    try w.print(
+        \\  const dialectRecords = [];
+        \\  const dialectOverlays = [];
+        \\  const dialectActive = new WeakSet();
+        \\  function encDialectRecord(n, schema, hostIdx) {{
+        \\    if (dialectActive.has(n)) throw new Error("yuku-codegen: cyclic dialect record");
+        \\    dialectActive.add(n);
+        \\    try {{
+        \\      const values = [];
+        \\      for (const field of schema.fields) {{
+        \\        const v = n[field.name];
+        \\        if (field.role === "host") values.push(hostIdx);
+        \\        else {{
+        \\          if (!Object.prototype.hasOwnProperty.call(n, field.name))
+        \\            throw new Error(`yuku-codegen: missing required dialect field ${{field.name}}`);
+        \\          if (field.role === "bool") {{
+        \\            if (typeof v !== "boolean") throw new Error("yuku-codegen: invalid dialect boolean " + field.name);
+        \\            values.push(v);
+        \\          }} else if (field.role === "scalar") {{
+        \\            if (!Number.isInteger(v) || v < 0 || v > 0xFFFFFFFF) throw new Error("yuku-codegen: invalid dialect scalar " + field.name);
+        \\            values.push(v);
+        \\          }} else if (field.role === "node") {{
+        \\            if (v == null || typeof v !== "object") throw new Error("yuku-codegen: invalid dialect node " + field.name);
+        \\            values.push(encNode(v));
+        \\          }} else if (field.role === "optionalNode") {{
+        \\            if (v != null && typeof v !== "object") throw new Error("yuku-codegen: invalid optional dialect node " + field.name);
+        \\            values.push(v == null ? NULL : encNode(v));
+        \\          }} else if (field.role === "nodeList") {{
+        \\            if (!Array.isArray(v)) throw new Error("yuku-codegen: invalid dialect node list " + field.name);
+        \\            values.push(encArr(v, encNode));
+        \\          }} else if (field.role === "string") {{
+        \\            if (typeof v !== "string") throw new Error("yuku-codegen: invalid dialect string " + field.name);
+        \\            values.push(encStr(v));
+        \\          }}
+        \\        }}
+        \\      }}
+        \\      const ab = new ArrayBuffer(NODE_SIZE), u8 = new Uint8Array(ab), u32 = new Uint32Array(ab);
+        \\      u8[0] = schema.tag;
+        \\      let packedFlags = 0;
+        \\      for (let i = 0; i < schema.fields.length; i++) {{
+        \\        const field = schema.fields[i], v = values[i];
+        \\        if (field.role === "bool") {{ if (v) packedFlags |= 1 << field.bit; }}
+        \\        else if (field.role === "nodeList") {{ u32[field.slot] = v.start; u32[field.slot + 1] = v.len; }}
+        \\        else if (field.role === "string") {{ u32[field.slot] = v.start; u32[field.slot + 1] = v.end; }}
+        \\        else u32[field.slot] = v >>> 0;
+        \\      }}
+        \\      new DataView(ab).setUint16({[flags_off]d}, packedFlags, true);
+        \\      const ri = dialectRecords.length;
+        \\      dialectRecords.push(ab);
+        \\      return ri;
+        \\    }} finally {{ dialectActive.delete(n); }}
+        \\  }}
+        \\  function encDialectDirect(n, schema) {{
+        \\    const ri = encDialectRecord(n, schema, NULL);
+        \\    const idx = alloc(); tagAt(idx, {[dialect_tag]d}); slotAt(idx, 0, ri);
+        \\    spanAt(idx, asStart(n), asEnd(n)); recordComments(n, idx); return idx;
+        \\  }}
+        \\
+    , .{ .flags_off = rt.NODE_FLAGS_OFFSET, .dialect_tag = rt.dialectNodeTag() });
+}
+
 fn writeIdentifierHelpers(w: *Writer) !void {
     try w.writeAll(
         \\  function encBindingTarget(n) {
@@ -261,7 +351,7 @@ fn writeNodeEncoders(w: *Writer) !void {
 // function_body (tag 5) and block_statement (tag 4) both decode to BlockStatement, the encoder emits block_statement
 fn skipGeneration(comptime name: []const u8) bool {
     @setEvalBranchQuota(20_000);
-    return std.mem.eql(u8, name, "function_body");
+    return !meta.includeNode(name) or std.mem.eql(u8, name, "function_body");
 }
 
 fn writeGenericEncoder(
@@ -316,7 +406,9 @@ fn writeGenericEncoder(
     inline for (std.meta.fields(T), 0..) |f, i| {
         const slot = comptime rt.u32SlotForField(T, i);
         const jsf = comptime meta.estreeField(name, f.name);
-        if (f.type == ast.NodeIndex) {
+        if (f.type == u32) {
+            try w.print("    slotAt(idx, {d}, n.{s});\n", .{ slot, jsf });
+        } else if (f.type == ast.NodeIndex) {
             try w.print("    slotAt(idx, {d}, c_{s});\n", .{ slot, f.name });
         } else if (f.type == ast.IndexRange) {
             switch (comptime rt.rangeIndexOf(T, i)) {
@@ -453,12 +545,12 @@ fn isFlagField(comptime F: type) bool {
     if (F == bool) return true;
     if (F == ?ast.ImportPhase) return true;
     if (F == ?ast.Hashbang) return true;
-    if (F == ast.NodeIndex or F == ast.IndexRange or F == ast.String) return false;
+    if (F == u32 or F == ast.NodeIndex or F == ast.IndexRange or F == ast.String) return false;
     return @typeInfo(F) == .@"enum";
 }
 
 fn isEnumFlag(comptime F: type) bool {
-    if (F == ast.NodeIndex or F == ast.IndexRange or F == ast.String) return false;
+    if (F == u32 or F == ast.NodeIndex or F == ast.IndexRange or F == ast.String) return false;
     return @typeInfo(F) == .@"enum";
 }
 
@@ -1344,9 +1436,12 @@ fn writeSpecialTSIndexSig(w: *Writer, comptime tag: usize) !void {
 }
 
 fn writeDispatcher(w: *Writer) !void {
+    try w.writeAll("  const commentsByIdx = new Map();\n");
+    try w.writeAll(if (comptime parser.dialect_enabled)
+        "  function encNodeInner(n) {\n"
+    else
+        "  function encNode(n) {\n");
     try w.writeAll(
-        \\  const commentsByIdx = new Map();
-        \\  function encNode(n) {
         \\    if (n == null) return NULL;
         \\    switch (n.type) {
         \\      case "Identifier": return enc_identifier_reference(n);
@@ -1394,6 +1489,24 @@ fn writeDispatcher(w: *Writer) !void {
     try w.writeAll(
         \\      default: throw new Error("yuku-codegen: unsupported ESTree node type: " + n.type);
         \\    }
+        \\  }
+        \\
+    );
+    if (comptime parser.dialect_enabled) try w.writeAll(
+        \\  function encNode(n) {
+        \\    if (n == null) return NULL;
+        \\    const direct = DIALECT_RECORDS.filter(s => !s.overlay && s.type === n.type);
+        \\    if (direct.length > 1) throw new Error("yuku-codegen: ambiguous direct dialect schema " + n.type);
+        \\    if (direct.length === 1) return encDialectDirect(n, direct[0]);
+        \\    const idx = encNodeInner(n);
+        \\    const overlays = DIALECT_RECORDS.filter(s => s.overlay && s.type === n.type &&
+        \\      s.fields.some(f => f.role !== "host" && Object.prototype.hasOwnProperty.call(n, f.name)));
+        \\    if (overlays.length > 1) throw new Error("yuku-codegen: ambiguous overlay dialect schema " + n.type);
+        \\    if (overlays.length === 1) {
+        \\      const ri = encDialectRecord(n, overlays[0], idx);
+        \\      dialectOverlays.push({ host: idx, record: ri });
+        \\    }
+        \\    return idx;
         \\  }
         \\
     );
@@ -1455,6 +1568,7 @@ fn writeAssemble(w: *Writer) !void {
         \\      }}
         \\    }}
         \\  }}
+        \\{[dialect_decl]s}
         \\  const totalNodeBytes = nodeCount * NODE_SIZE;
         \\  const totalExtraBytes = extraCount * 4;
         \\  const totalPoolBytes = (poolLen + 3) & ~3;
@@ -1462,7 +1576,7 @@ fn writeAssemble(w: *Writer) !void {
         \\  const totalAttachedBytes = attachedCount * ATTACHED_COMMENT_SIZE;
         \\  const finalSize =
         \\    HEADER_SIZE + totalNodeBytes + totalExtraBytes + totalPoolBytes +
-        \\    totalOffsetsBytes + totalAttachedBytes;
+        \\    totalOffsetsBytes + totalAttachedBytes{[dialect_size]s};
         \\  const out = new ArrayBuffer(finalSize);
         \\  const outU8 = new Uint8Array(out);
         \\  const outU32 = new Uint32Array(out, 0, (finalSize >>> 2));
@@ -1474,7 +1588,7 @@ fn writeAssemble(w: *Writer) !void {
         \\  outU32[{[u_acc]d}] = attachedCount;
         \\  outU32[{[u_dc]d}] = 0;
         \\  outU32[{[u_pi]d}] = progIdx;
-        \\  outU32[{[u_fl]d}] = attached ? FLAG_ATTACHED_COMMENTS : 0;
+        \\  outU32[{[u_fl]d}] = {[flags_expr]s};
         \\  outU32[{[u_fna]d}] = 0;
         \\  const nodesOff = HEADER_SIZE;
         \\  const extrasOff = nodesOff + totalNodeBytes;
@@ -1486,6 +1600,7 @@ fn writeAssemble(w: *Writer) !void {
         \\  outU8.set(pool.subarray(0, poolLen), poolOff);
         \\  if (offsetsBytes !== null) outU8.set(new Uint8Array(offsetsBytes), offsetsOff);
         \\  if (attachedBytes !== null) outU8.set(new Uint8Array(attachedBytes), attachedOff);
+        \\{[dialect_copy]s}
         \\  return out;
         \\}}
         \\
@@ -1500,5 +1615,30 @@ fn writeAssemble(w: *Writer) !void {
         .u_pi = rt.HDR_PROGRAM_INDEX_U32,
         .u_fl = rt.HDR_FLAGS_U32,
         .u_fna = rt.HDR_FIRST_NON_ASCII_U32,
+        .dialect_decl = if (comptime parser.dialect_enabled)
+            \\  dialectOverlays.sort((a, b) => a.host - b.host);
+            \\  const totalDialectBytes = dialectRecords.length === 0 ? 0
+            \\    : 8 + dialectRecords.length * NODE_SIZE + dialectOverlays.length * 8;
+        else
+            "",
+        .dialect_size = if (comptime parser.dialect_enabled) " + totalDialectBytes" else "",
+        .flags_expr = if (comptime parser.dialect_enabled)
+            comptime std.fmt.comptimePrint("(attached ? FLAG_ATTACHED_COMMENTS : 0) | (root[DIALECT_TS] === true ? {d} : 0) | (dialectRecords.length ? {d} : 0)", .{ rt.FLAG_TS, rt.FLAG_DIALECT_RECORDS })
+        else
+            "attached ? FLAG_ATTACHED_COMMENTS : 0",
+        .dialect_copy = if (comptime parser.dialect_enabled)
+            \\  if (dialectRecords.length) {
+            \\    const dialectOff = attachedOff + totalAttachedBytes;
+            \\    const dv = new DataView(out);
+            \\    dv.setUint32(dialectOff, dialectRecords.length, true);
+            \\    dv.setUint32(dialectOff + 4, dialectOverlays.length, true);
+            \\    let p = dialectOff + 8;
+            \\    for (const record of dialectRecords) { outU8.set(new Uint8Array(record), p); p += NODE_SIZE; }
+            \\    for (const overlay of dialectOverlays) {
+            \\      dv.setUint32(p, overlay.host, true); dv.setUint32(p + 4, overlay.record, true); p += 8;
+            \\    }
+            \\  }
+        else
+            "",
     });
 }

--- a/tools/estree/meta.zig
+++ b/tools/estree/meta.zig
@@ -86,6 +86,11 @@ pub fn estreeType(comptime name: []const u8) []const u8 {
     return snakeConvert(name, true);
 }
 
+pub fn includeNode(comptime name: []const u8) bool {
+    if (comptime std.mem.eql(u8, name, "dialect_node")) return parser.dialect_enabled;
+    return true;
+}
+
 pub fn estreeField(comptime tag: []const u8, comptime field: []const u8) []const u8 {
     if (comptime std.mem.eql(u8, tag, "variable_declaration") and
         std.mem.eql(u8, field, "declarators")) return "declarations";
@@ -93,6 +98,53 @@ pub fn estreeField(comptime tag: []const u8, comptime field: []const u8) []const
     if (comptime std.mem.eql(u8, tag, "ts_enum_declaration") and
         std.mem.eql(u8, field, "is_const")) return "const";
     return snakeConvert(field, false);
+}
+
+pub fn dialectRoleName(comptime T: type) []const u8 {
+    if (T == bool) return "bool";
+    if (@typeInfo(T) == .@"struct" and @hasDecl(T, "dialect_role")) {
+        return switch (T.dialect_role) {
+            .scalar_u32 => "scalar",
+            .node_ref => "node",
+            .optional_node_ref => "optionalNode",
+            .node_list => "nodeList",
+            .string_slice => "string",
+            .overlay_host => "host",
+        };
+    }
+    @compileError("unsupported dialect field ABI type: " ++ @typeName(T));
+}
+
+pub fn dialectRecordType(comptime name: []const u8, comptime T: type) []const u8 {
+    if (@typeInfo(T) == .@"struct" and @hasDecl(T, "estree_type")) return T.estree_type;
+    return estreeType(name);
+}
+
+pub fn dialectRecordIsOverlay(comptime T: type) bool {
+    var hosts: usize = 0;
+    for (std.meta.fields(T)) |field| {
+        if (std.mem.eql(u8, dialectRoleName(field.type), "host")) hosts += 1;
+    }
+    if (hosts > 1) @compileError("ambiguous dialect overlay schema in " ++ @typeName(T));
+    return hosts == 1;
+}
+
+pub fn validateDialectSchema() void {
+    if (!parser.dialect_enabled) return;
+    for (@typeInfo(parser.dialect_schema.Record).@"union".fields, 0..) |record, record_index| {
+        for (std.meta.fields(record.type), 0..) |field, i| {
+            for (std.meta.fields(record.type)[0..i]) |prior| {
+                if (std.mem.eql(u8, estreeField(record.name, field.name), estreeField(record.name, prior.name)))
+                    @compileError("ambiguous duplicate reflected dialect field in " ++ record.name);
+            }
+        }
+        const is_overlay = dialectRecordIsOverlay(record.type);
+        for (@typeInfo(parser.dialect_schema.Record).@"union".fields[0..record_index]) |prior| {
+            const same_kind = is_overlay == dialectRecordIsOverlay(prior.type);
+            if (same_kind and std.mem.eql(u8, dialectRecordType(record.name, record.type), dialectRecordType(prior.name, prior.type)))
+                @compileError("ambiguous reflected dialect ESTree type " ++ dialectRecordType(record.name, record.type));
+        }
+    }
 }
 
 // arrays that allow holes, sparse elements become null in ESTree


### PR DESCRIPTION
## What

- Add generic dialect traversal hooks for reflected child records.
- Extend generic semantic scope handling for dialect-owned records.
- Add generic printer delegation for dialect code generation.
- Keep all TSRX policy and identifiers out of Yuku.

## Why

This is the minimal generic seam required for downstream compile-time dialects to reuse Yuku parsing, semantic analysis, and code generation without forking the parser or adding dialect-specific knowledge to Yuku.

## Impact

The seam remains compile-time optional and default-off. Ordinary TypeScript/JSX and dialect-free generated output retain their existing behavior.

## Checks

- `zig fmt --check .`
- `zig build test`
- `bun run typecheck`
- `bun run test:parser`
- `bun run test`
- zero case-insensitive `tsrx` identifiers in `src/` and `tools/`

