### PR TITLE
fix(analyzer): bind lowercase JSX member roots

### DIFF
--- a/src/parser/semantic/binder.zig
+++ b/src/parser/semantic/binder.zig
@@ -1103,14 +1103,17 @@ pub const SymbolTracker = struct {
                 _ = try self.declare(name, member.id);
                 self.pending = saved;
             },
-            // the leftmost capitalized `jsx_identifier` of a tag is a js
-            // binding reference. lowercase tags (`<div>`) are intrinsic
-            // element names and the rest of the chain is property syntax.
+            // a member tag evaluates its leftmost object regardless of casing.
+            // direct lowercase tags are intrinsic names. the rest is property syntax.
             inline .jsx_opening_element, .jsx_closing_element => |el| {
                 if (jsxTagRoot(self.tree, el.name)) |root_idx| {
                     const id = self.tree.data(root_idx).jsx_identifier;
                     const text = self.tree.string(id.name);
-                    if (text.len > 0 and text[0] >= 'A' and text[0] <= 'Z') {
+                    const member = switch (self.tree.data(el.name)) {
+                        .jsx_member_expression => true,
+                        else => false,
+                    };
+                    if (member or (text.len > 0 and text[0] >= 'A' and text[0] <= 'Z')) {
                         _ = try self.addReference(id.name, scope.current, root_idx, .{});
                     }
                 }

--- a/test/analyzer/references.test.ts
+++ b/test/analyzer/references.test.ts
@@ -248,6 +248,22 @@ describe("JSX", () => {
             function "Foo""
       `);
   });
+
+  test("a lowercase member root resolves while a direct lowercase tag stays intrinsic", () => {
+    // member roots are expressions while direct lowercase tags are intrinsic
+    expect(
+      summary(`const motion = {}; const App = () => <><motion.div /><div /></>;`, {
+        path: "input.jsx",
+      }),
+    ).toMatchInlineSnapshot(`
+        "global
+          module [strict]
+            motion#0  const
+            App#1  const
+            function =>
+              motion → #0"
+      `);
+  });
 });
 
 describe("reference cross-indexes", () => {


### PR DESCRIPTION
### Problem

JSX member tags evaluate their leftmost object as a value expression regardless of capitalization. The analyzer only recorded capitalized tag roots, so a lowercase namespace-style root such as `motion` in `<motion.div />` was not bound as a reference.

Direct lowercase tags such as `<div />` are intrinsic element names and should remain unbound.

### Fix

Record the leftmost root of JSX member tags as a value reference regardless of casing, while keeping the capitalization check for direct JSX tags. Add regression coverage for both cases.

Related issue: https://github.com/fireairforce/utoo-lint/issues/1045
