### PR TITLE
feat(parser): allow_return_outside_function option

### DIFF
--- a/npm/yuku-analyzer-wasm/binding.js
+++ b/npm/yuku-analyzer-wasm/binding.js
@@ -23,6 +23,7 @@ function packFlags(o = {}) {
   let f = (SOURCE_TYPES[o.sourceType] ?? 1) | ((LANGS[o.lang] ?? 0) << 2);
   if (o.preserveParens !== false) f |= 1 << 5;
   if (o.attachComments) f |= 1 << 7;
+  if (o.allowReturnOutsideFunction) f |= 1 << 8;
   return f;
 }
 

--- a/npm/yuku-parser-wasm/index.js
+++ b/npm/yuku-parser-wasm/index.js
@@ -27,6 +27,7 @@ function packFlags(o = {}) {
   if (o.preserveParens !== false) f |= 1 << 5;
   if (o.semanticErrors) f |= 1 << 6;
   if (o.attachComments) f |= 1 << 7;
+  if (o.allowReturnOutsideFunction) f |= 1 << 8;
   return f;
 }
 

--- a/src/parser/ffi/analyzer.zig
+++ b/src/parser/ffi/analyzer.zig
@@ -7,6 +7,7 @@ const Options = struct {
     source_type: parser.ast.SourceType = .module,
     lang: parser.ast.Lang = .js,
     preserve_parens: bool = true,
+    allow_return_outside_function: bool = false,
     attach_comments: bool = false,
 };
 
@@ -18,6 +19,7 @@ pub fn analyze(env: napi.Env, source: []const u8, options: Options) !napi.Val {
         .source_type = options.source_type,
         .lang = options.lang,
         .preserve_parens = options.preserve_parens,
+        .allow_return_outside_function = options.allow_return_outside_function,
         .comments = if (options.attach_comments) .both else .flat,
     }) catch return error.AnalyzeFailed;
     defer tree.deinit();

--- a/src/parser/ffi/parser.zig
+++ b/src/parser/ffi/parser.zig
@@ -7,6 +7,7 @@ const Options = struct {
     source_type: parser.ast.SourceType = .module,
     lang: parser.ast.Lang = .js,
     preserve_parens: bool = true,
+    allow_return_outside_function: bool = false,
     semantic_errors: bool = false,
     attach_comments: bool = false,
 };
@@ -16,6 +17,7 @@ pub fn parse(env: napi.Env, source: []const u8, options: Options) !napi.Val {
         .source_type = options.source_type,
         .lang = options.lang,
         .preserve_parens = options.preserve_parens,
+        .allow_return_outside_function = options.allow_return_outside_function,
         .comments = if (options.attach_comments) .both else .flat,
     }) catch return error.ParseFailed;
     defer tree.deinit();

--- a/src/parser/ffi/wasm/analyzer.zig
+++ b/src/parser/ffi/wasm/analyzer.zig
@@ -21,6 +21,7 @@ const flag = struct {
     const lang_shift = 2; // bits 2..4: ast.Lang index
     const preserve_parens = 1 << 5;
     const attach_comments = 1 << 7;
+    const allow_return = 1 << 8;
 };
 
 export fn alloc(len: usize) [*]u8 {
@@ -41,6 +42,7 @@ fn run(source: []const u8, flags: u32) ![]u8 {
         .source_type = @enumFromInt(@as(u2, @truncate(flags & flag.source_type_mask))),
         .lang = @enumFromInt(@as(u3, @truncate(flags >> flag.lang_shift))),
         .preserve_parens = flags & flag.preserve_parens != 0,
+        .allow_return_outside_function = flags & flag.allow_return != 0,
         .comments = if (flags & flag.attach_comments != 0) .both else .flat,
     });
     defer tree.deinit();

--- a/src/parser/ffi/wasm/parser.zig
+++ b/src/parser/ffi/wasm/parser.zig
@@ -20,6 +20,7 @@ const flag = struct {
     const preserve_parens = 1 << 5;
     const semantic = 1 << 6;
     const attach_comments = 1 << 7;
+    const allow_return = 1 << 8;
 };
 
 export fn alloc(len: usize) [*]u8 {
@@ -40,6 +41,7 @@ fn run(source: []const u8, flags: u32) ![]u8 {
         .source_type = @enumFromInt(@as(u2, @truncate(flags & flag.source_type_mask))),
         .lang = @enumFromInt(@as(u3, @truncate(flags >> flag.lang_shift))),
         .preserve_parens = flags & flag.preserve_parens != 0,
+        .allow_return_outside_function = flags & flag.allow_return != 0,
         .comments = if (flags & flag.attach_comments != 0) .both else .flat,
     });
     defer tree.deinit();

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -40,6 +40,9 @@ pub const Options = struct {
     /// `ParenthesizedExpression` nodes in the AST. When false,
     /// parentheses are stripped and only the inner expression is kept.
     preserve_parens: bool = true,
+    /// When true, `return` statements are allowed at the top level,
+    /// outside of any function. Defaults to false.
+    allow_return_outside_function: bool = false,
     /// Whether and how comments are collected. Defaults to `.flat`: comments
     /// land in the flat `tree.comments` list with no per-node attachment.
     comments: CommentMode = .flat,
@@ -96,6 +99,7 @@ pub const Parser = struct {
     source_type: ast.SourceType,
     lang: ast.Lang,
     preserve_parens: bool,
+    allow_return_outside_function: bool,
     comment_mode: CommentMode,
     lexer: lexer.Lexer,
     diagnostics: std.ArrayList(ast.Diagnostic) = .empty,
@@ -130,6 +134,7 @@ pub const Parser = struct {
             .source_type = options.source_type,
             .lang = options.lang,
             .preserve_parens = options.preserve_parens,
+            .allow_return_outside_function = options.allow_return_outside_function,
             .comment_mode = options.comments,
             .lexer = undefined,
             .current_token = Token.eof(0),
@@ -160,7 +165,7 @@ pub const Parser = struct {
         // commonjs top level is a function body, so [+Return]
         self.context.yield = false;
         self.context.await = self.tree.isModule();
-        self.context.@"return" = self.source_type == .commonjs;
+        self.context.@"return" = self.allow_return_outside_function or self.source_type == .commonjs;
 
         // a `.d.ts` file is ambient throughout
         self.ts_context.ambient = self.lang == .dts;

--- a/src/parser/testing/cases/diagnostics.zig
+++ b/src/parser/testing/cases/diagnostics.zig
@@ -81,3 +81,24 @@ test "lookahead-driven keywords still parse cleanly when the next token is valid
         }
     }
 }
+
+// `return` at the top level is a syntax error in scripts and modules, but
+// embedders that parse a function body as a program can opt in. commonjs
+// keeps its implicit [+Return] regardless of the option.
+test "allow_return_outside_function toggles top-level return" {
+    const source = "return 42;";
+
+    try expectRejected(source, .{ .source_type = .script, .lang = .js });
+    try expectRejected(source, .{ .source_type = .module, .lang = .js });
+
+    const opts = [_]parser.Options{
+        .{ .source_type = .script, .lang = .js, .allow_return_outside_function = true },
+        .{ .source_type = .module, .lang = .js, .allow_return_outside_function = true },
+        .{ .source_type = .commonjs, .lang = .js },
+    };
+    for (opts) |o| {
+        var tree = try parser.parse(testing.allocator, source, o);
+        defer tree.deinit();
+        try testing.expectEqual(@as(usize, 0), tree.diagnostics.items.len);
+    }
+}


### PR DESCRIPTION
Adds an opt-in `allow_return_outside_function` parser option (default `false`), for embedders that parse a function body as a program. Same knob as acorn/babel/oxc expose under that name.

Only change in behavior is the initial `[Return]` context: `commonjs` keeps its implicit top-level return, and script/module get it only when the option is set. Exposed on the native and wasm entry points (bit 8 on wasm) for parser and analyzer.

Small and independent of #164, so sending it on its own. Test covers both the rejected default and the three accepting configurations.